### PR TITLE
feat: 회원가입/로그인 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,11 @@ dependencies {
     // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     // h2
     testRuntimeOnly 'com.h2database:h2'
 

--- a/config/formatter/courseitda-style.xml
+++ b/config/formatter/courseitda-style.xml
@@ -302,7 +302,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
-		<setting id="org.eclipse.jdt.core.formatter.alignment_for_record_components" value="18"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_record_components" value="16"/>
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_record_declaration" value="16"/>
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>

--- a/src/main/java/courseitda/auth/application/AuthService.java
+++ b/src/main/java/courseitda/auth/application/AuthService.java
@@ -1,0 +1,30 @@
+package courseitda.auth.application;
+
+import org.springframework.stereotype.Service;
+
+import courseitda.auth.domain.AuthTokenProvider;
+import courseitda.auth.ui.dto.request.LoginRequest;
+import courseitda.exception.auth.AuthenticationException;
+import courseitda.exception.resource.ResourceNotFoundException;
+import courseitda.member.domain.Member;
+import courseitda.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthTokenProvider authTokenProvider;
+    private final MemberRepository memberRepository;
+
+    public String login(final LoginRequest request) {
+        final Member member = memberRepository.findByEmail(request.email())
+                .orElseThrow(() -> new ResourceNotFoundException("해당 이메일을 가진 회원이 존재하지 않습니다."));
+
+        if (member.isWrongPassword(request.password())) {
+            throw new AuthenticationException("비밀번호가 올바르지 않습니다.");
+        }
+
+        return authTokenProvider.createAccessToken(member.getId().toString(), member.getAuthRole());
+    }
+}

--- a/src/main/java/courseitda/auth/config/AuthWebMvcConfig.java
+++ b/src/main/java/courseitda/auth/config/AuthWebMvcConfig.java
@@ -1,0 +1,36 @@
+package courseitda.auth.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import courseitda.auth.domain.AuthTokenExtractor;
+import courseitda.auth.domain.AuthTokenProvider;
+import courseitda.auth.ui.MemberAuthInfoArgumentResolver;
+import courseitda.auth.ui.interceptor.AuthRoleCheckInterceptor;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthWebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthTokenExtractor<String> authTokenExtractor;
+    private final AuthTokenProvider authTokenProvider;
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(
+                new AuthRoleCheckInterceptor(authTokenExtractor, authTokenProvider)
+        )
+                .addPathPatterns("/**")
+                .excludePathPatterns("/css/**", "/js/**", "/image/**", "/login", "/signup", "/");
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new MemberAuthInfoArgumentResolver(authTokenExtractor, authTokenProvider));
+    }
+}

--- a/src/main/java/courseitda/auth/domain/AuthRole.java
+++ b/src/main/java/courseitda/auth/domain/AuthRole.java
@@ -1,0 +1,18 @@
+package courseitda.auth.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum AuthRole {
+
+    ADMIN("관리자"), // 시스템 관리자
+    MEMBER("일반 회원"), // 회원가입한 일반 회원
+    GUEST("게스트") // 회원가입하지 않은 게스트
+    ;
+
+    private final String roleName;
+
+    AuthRole(final String roleName) {
+        this.roleName = roleName;
+    }
+}

--- a/src/main/java/courseitda/auth/domain/AuthTokenExtractor.java
+++ b/src/main/java/courseitda/auth/domain/AuthTokenExtractor.java
@@ -1,0 +1,14 @@
+package courseitda.auth.domain;
+
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface AuthTokenExtractor<T> {
+
+    String AUTH_TOKEN_NAME = "token";
+
+    boolean isCookiesExist(HttpServletRequest request);
+
+    @Nullable
+    T extract(HttpServletRequest request);
+}

--- a/src/main/java/courseitda/auth/domain/AuthTokenProvider.java
+++ b/src/main/java/courseitda/auth/domain/AuthTokenProvider.java
@@ -1,0 +1,16 @@
+package courseitda.auth.domain;
+
+import java.time.Instant;
+
+public interface AuthTokenProvider {
+
+    String createAccessToken(String principal, AuthRole role);
+
+    String getPrincipal(String token);
+
+    Instant getExpiration(String token);
+
+    AuthRole getRole(String token);
+
+    boolean isValidToken(String token);
+}

--- a/src/main/java/courseitda/auth/domain/MemberAuthInfo.java
+++ b/src/main/java/courseitda/auth/domain/MemberAuthInfo.java
@@ -1,0 +1,7 @@
+package courseitda.auth.domain;
+
+public record MemberAuthInfo(
+        Long id,
+        AuthRole authRole
+) {
+}

--- a/src/main/java/courseitda/auth/domain/RequiresRole.java
+++ b/src/main/java/courseitda/auth/domain/RequiresRole.java
@@ -1,0 +1,13 @@
+package courseitda.auth.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiresRole {
+
+    AuthRole[] authRoles();
+}

--- a/src/main/java/courseitda/auth/infrastructure/JwtTokenExtractor.java
+++ b/src/main/java/courseitda/auth/infrastructure/JwtTokenExtractor.java
@@ -1,0 +1,34 @@
+package courseitda.auth.infrastructure;
+
+import java.util.Arrays;
+
+import org.springframework.stereotype.Component;
+
+import courseitda.auth.domain.AuthTokenExtractor;
+import courseitda.exception.auth.AuthTokenNotFoundException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class JwtTokenExtractor implements AuthTokenExtractor<String> {
+
+    @Override
+    public boolean isCookiesExist(final HttpServletRequest request) {
+        final Cookie[] cookies = request.getCookies();
+
+        return cookies != null;
+    }
+
+    public String extract(final HttpServletRequest request) {
+        final Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            throw new AuthTokenNotFoundException("쿠키가 존재하지 않습니다.");
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> AUTH_TOKEN_NAME.equals(cookie.getName()))
+                .findFirst()
+                .map(Cookie::getValue)
+                .orElseThrow(() -> new AuthTokenNotFoundException("쿠키에 " + AUTH_TOKEN_NAME + "이 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/courseitda/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/courseitda/auth/infrastructure/JwtTokenProvider.java
@@ -1,0 +1,122 @@
+package courseitda.auth.infrastructure;
+
+import static courseitda.auth.domain.AuthRole.GUEST;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import courseitda.auth.domain.AuthRole;
+import courseitda.auth.domain.AuthTokenProvider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+
+@Component
+public class JwtTokenProvider implements AuthTokenProvider {
+
+    private final SecretKey secretKey;
+    @Value("${security.jwt.access-token.validity-in-milliseconds}")
+    private long validityInMilliseconds;
+
+    public JwtTokenProvider(@Value("${security.jwt.access-token.secret-key}") final String secretKeyValue) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyValue.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createAccessToken(final String principal, final AuthRole role) {
+        final Claims claims = Jwts.claims()
+                .subject(principal)
+                .build();
+        final Date now = new Date();
+        final Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(validity)
+                .claim("role", role.name())
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String getPrincipal(final String token) {
+        if (token == null || token.isEmpty()) {
+            return null;
+        }
+
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    public Instant getExpiration(final String token) {
+        if (token == null || token.isEmpty()) {
+            return null;
+        }
+
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration()
+                .toInstant();
+    }
+
+    public AuthRole getRole(final String token) {
+        if (token == null || token.isEmpty()) {
+            return GUEST;
+        }
+
+        final String role = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role", String.class);
+
+        return AuthRole.valueOf(role);
+    }
+
+    public boolean isValidToken(final String token) {
+        if (token == null || token.isEmpty()) {
+            return false;
+        }
+
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (final MalformedJwtException e) {
+            // Header.Payload.Signature 3개 파트로 나누어지지 않은 경우, Base64 디코딩이 불가능한 경우, JSON 형태가 아닌 경우
+            return false;
+        } catch (final ExpiredJwtException e) {
+            // 토큰이 만료된 경우
+            return false;
+        } catch (final UnsupportedJwtException e) {
+            // 지원하지 않는 암호화 방식을 사용한 경우 ("alg" 필드로 검증)
+            return false;
+        } catch (final SignatureException e) {
+            // 서명이 올바르지 않은 경우(올바른 SecretKey로 서명되지 않은 경우)
+            return false;
+        } catch (final JwtException e) {
+            // 기타 예외
+            return false;
+        }
+    }
+}

--- a/src/main/java/courseitda/auth/ui/AuthController.java
+++ b/src/main/java/courseitda/auth/ui/AuthController.java
@@ -1,0 +1,29 @@
+package courseitda.auth.ui;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import courseitda.auth.application.AuthService;
+import courseitda.auth.ui.dto.request.LoginRequest;
+import courseitda.auth.ui.dto.response.LoginResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(
+            @RequestBody @Valid final LoginRequest request
+    ) {
+        final String authToken = authService.login(request);
+        final LoginResponse loginResponse = new LoginResponse("Bearer", authToken);
+
+        return ResponseEntity.ok(loginResponse);
+    }
+}

--- a/src/main/java/courseitda/auth/ui/MemberAuthInfoArgumentResolver.java
+++ b/src/main/java/courseitda/auth/ui/MemberAuthInfoArgumentResolver.java
@@ -1,0 +1,42 @@
+package courseitda.auth.ui;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import courseitda.auth.domain.AuthRole;
+import courseitda.auth.domain.AuthTokenExtractor;
+import courseitda.auth.domain.AuthTokenProvider;
+import courseitda.auth.domain.MemberAuthInfo;
+import courseitda.exception.auth.AuthenticationException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemberAuthInfoArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthTokenExtractor<String> authTokenExtractor;
+    private final AuthTokenProvider authTokenProvider;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.getParameterType().equals(MemberAuthInfo.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+
+        final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        final String token = authTokenExtractor.extract(request);
+        if (!authTokenProvider.isValidToken(token)) {
+            throw new AuthenticationException("유효하지 않은 토큰입니다.");
+        }
+        final Long id = Long.parseLong(authTokenProvider.getPrincipal(token));
+        final AuthRole role = authTokenProvider.getRole(token);
+
+        return new MemberAuthInfo(id, role);
+    }
+}

--- a/src/main/java/courseitda/auth/ui/dto/request/LoginRequest.java
+++ b/src/main/java/courseitda/auth/ui/dto/request/LoginRequest.java
@@ -1,0 +1,9 @@
+package courseitda.auth.ui.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank String email,
+        @NotBlank String password
+) {
+}

--- a/src/main/java/courseitda/auth/ui/dto/response/LoginResponse.java
+++ b/src/main/java/courseitda/auth/ui/dto/response/LoginResponse.java
@@ -1,0 +1,7 @@
+package courseitda.auth.ui.dto.response;
+
+public record LoginResponse(
+        String tokenType,
+        String accessToken
+) {
+}

--- a/src/main/java/courseitda/auth/ui/interceptor/AuthRoleCheckInterceptor.java
+++ b/src/main/java/courseitda/auth/ui/interceptor/AuthRoleCheckInterceptor.java
@@ -1,0 +1,58 @@
+package courseitda.auth.ui.interceptor;
+
+import java.util.Arrays;
+
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import courseitda.auth.domain.AuthRole;
+import courseitda.auth.domain.AuthTokenExtractor;
+import courseitda.auth.domain.AuthTokenProvider;
+import courseitda.auth.domain.RequiresRole;
+import courseitda.exception.auth.AuthenticationException;
+import courseitda.exception.auth.AuthorizationException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AuthRoleCheckInterceptor implements HandlerInterceptor {
+
+    private final AuthTokenExtractor<String> authTokenExtractor;
+    private final AuthTokenProvider authTokenProvider;
+
+    @Override
+    public boolean preHandle(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Object handler
+    ) throws AuthenticationException {
+        if (!(handler instanceof final HandlerMethod handlerMethod)) {
+            return true;
+        }
+
+        // 1. 클래스에 @RequiresRole 어노테이션이 붙어있는지 확인
+        RequiresRole requiresRole = handlerMethod.getMethodAnnotation(RequiresRole.class);
+
+        // 2. 메서드에 @RequiresRole 어노테이션이 붙어있지 않으면 클래스에 붙어있는지 확인
+        if (requiresRole == null) {
+            requiresRole = handlerMethod.getBeanType().getAnnotation(RequiresRole.class);
+        }
+
+        if (requiresRole == null) {
+            return true;
+        }
+
+        final String accessToken = authTokenExtractor.extract(request);
+        if (!authTokenProvider.isValidToken(accessToken)) {
+            throw new AuthenticationException("유효하지 않은 토큰입니다.");
+        }
+
+        final AuthRole role = authTokenProvider.getRole(accessToken);
+        if (Arrays.stream(requiresRole.authRoles())
+                .noneMatch(authRole -> authRole == role)) {
+            throw new AuthorizationException("권한이 없습니다.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/courseitda/exception/auth/AuthTokenNotFoundException.java
+++ b/src/main/java/courseitda/exception/auth/AuthTokenNotFoundException.java
@@ -1,0 +1,8 @@
+package courseitda.exception.auth;
+
+public class AuthTokenNotFoundException extends RuntimeException {
+
+    public AuthTokenNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/courseitda/exception/auth/AuthenticationException.java
+++ b/src/main/java/courseitda/exception/auth/AuthenticationException.java
@@ -1,0 +1,8 @@
+package courseitda.exception.auth;
+
+public class AuthenticationException extends RuntimeException {
+
+    public AuthenticationException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/courseitda/exception/auth/AuthorizationException.java
+++ b/src/main/java/courseitda/exception/auth/AuthorizationException.java
@@ -1,0 +1,8 @@
+package courseitda.exception.auth;
+
+public class AuthorizationException extends RuntimeException {
+
+    public AuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/courseitda/exception/resource/AlreadyExistException.java
+++ b/src/main/java/courseitda/exception/resource/AlreadyExistException.java
@@ -1,0 +1,8 @@
+package courseitda.exception.resource;
+
+public class AlreadyExistException extends RuntimeException {
+
+    public AlreadyExistException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/courseitda/exception/resource/ResourceInUseException.java
+++ b/src/main/java/courseitda/exception/resource/ResourceInUseException.java
@@ -1,0 +1,8 @@
+package courseitda.exception.resource;
+
+public class ResourceInUseException extends RuntimeException {
+
+    public ResourceInUseException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/courseitda/exception/resource/ResourceNotFoundException.java
+++ b/src/main/java/courseitda/exception/resource/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package courseitda.exception.resource;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/courseitda/member/application/MemberService.java
+++ b/src/main/java/courseitda/member/application/MemberService.java
@@ -1,0 +1,26 @@
+package courseitda.member.application;
+
+import courseitda.member.domain.Member;
+import courseitda.member.domain.MemberRepository;
+import courseitda.member.ui.dto.request.SignUpRequest;
+import courseitda.member.ui.dto.response.SignUpResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public SignUpResponse create(final SignUpRequest request) {
+        final Member member = Member.builder()
+                .nickname(request.nickname())
+                .email(request.email())
+                .password(request.password())
+                .build();
+        final Member createdMember = memberRepository.save(member);
+
+        return SignUpResponse.from(createdMember);
+    }
+}

--- a/src/main/java/courseitda/member/application/MemberService.java
+++ b/src/main/java/courseitda/member/application/MemberService.java
@@ -1,11 +1,12 @@
 package courseitda.member.application;
 
+import org.springframework.stereotype.Service;
+
 import courseitda.member.domain.Member;
 import courseitda.member.domain.MemberRepository;
 import courseitda.member.ui.dto.request.SignUpRequest;
 import courseitda.member.ui.dto.response.SignUpResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/courseitda/member/domain/LoginAuthenticationProvider.java
+++ b/src/main/java/courseitda/member/domain/LoginAuthenticationProvider.java
@@ -1,0 +1,6 @@
+package courseitda.member.domain;
+
+public enum LoginAuthenticationProvider {
+    COURSEITDA, KAKAO,
+    ;
+}

--- a/src/main/java/courseitda/member/domain/Member.java
+++ b/src/main/java/courseitda/member/domain/Member.java
@@ -1,21 +1,23 @@
 package courseitda.member.domain;
 
-import java.time.LocalDateTime;
-import java.util.regex.Pattern;
-
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
-
+import courseitda.auth.domain.AuthRole;
 import courseitda.common.Timestamp;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
@@ -25,7 +27,7 @@ import lombok.NoArgsConstructor;
 @SQLDelete(sql = "UPDATE users SET deleted_at = NOW() WHERE id = ?")
 public class Member extends Timestamp {
 
-    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+    private static final Pattern MEMBER_EMAIL_PATTERN = Pattern.compile(
             "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$");
 
     @Id
@@ -41,6 +43,10 @@ public class Member extends Timestamp {
     @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private AuthRole authRole;
+
     private String profileImageUrl;
 
     private LoginAuthenticationProvider loginAuthenticationProvider;
@@ -48,4 +54,52 @@ public class Member extends Timestamp {
     private String loginAuthenticationIdentifier;
 
     private LocalDateTime deletedAt;
+
+    @Builder
+    public Member(
+            final String nickname,
+            final String email,
+            final String password,
+            final AuthRole authRole
+    ) {
+        validateNickname(nickname);
+        validateEmail(email);
+        validatePassword(password);
+
+        this.nickname = nickname;
+        this.email = email;
+        this.password = password;
+        this.authRole = authRole;
+    }
+
+    private void validateNickname(final String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new IllegalArgumentException("닉네임은 null 또는 공백일 수 없습니다.");
+        }
+        if (nickname.length() < 2 || nickname.length() > 20) {
+            throw new IllegalArgumentException("닉네임은 2자 이상 20자 이하이어야 합니다.");
+        }
+    }
+
+    private void validateEmail(final String email) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("이메일은 null 이거나 빈 문자열일 수 없습니다.");
+        }
+        if (!MEMBER_EMAIL_PATTERN.matcher(email).matches()) {
+            throw new IllegalArgumentException("유효한 이메일 형식이 아닙니다.");
+        }
+    }
+
+    private void validatePassword(final String password) {
+        if (password == null || password.isBlank()) {
+            throw new IllegalArgumentException("비밀번호는 null 이거나 빈 문자열일 수 없습니다.");
+        }
+        if (password.length() < 6 || password.length() > 20) {
+            throw new IllegalArgumentException("비밀번호는 6자 이상 20자 이하이어야 합니다.");
+        }
+    }
+
+    public boolean isWrongPassword(final String password) {
+        return !this.password.equals(password);
+    }
 }

--- a/src/main/java/courseitda/member/domain/Member.java
+++ b/src/main/java/courseitda/member/domain/Member.java
@@ -1,6 +1,7 @@
-package courseitda.user.domain;
+package courseitda.member.domain;
 
 import java.time.LocalDateTime;
+import java.util.regex.Pattern;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -18,11 +19,14 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "users")
+@Table(name = "members")
 @SQLRestriction("deleted_at is Null")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE users SET deleted_at = NOW() WHERE id = ?")
-public class User extends Timestamp {
+public class Member extends Timestamp {
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+            "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/courseitda/member/domain/Member.java
+++ b/src/main/java/courseitda/member/domain/Member.java
@@ -1,5 +1,11 @@
 package courseitda.member.domain;
 
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
 import courseitda.auth.domain.AuthRole;
 import courseitda.common.Timestamp;
 import jakarta.persistence.Column;
@@ -10,14 +16,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter

--- a/src/main/java/courseitda/member/domain/Member.java
+++ b/src/main/java/courseitda/member/domain/Member.java
@@ -1,21 +1,23 @@
 package courseitda.member.domain;
 
-import java.time.LocalDateTime;
-import java.util.regex.Pattern;
-
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
-
+import courseitda.auth.domain.AuthRole;
 import courseitda.common.Timestamp;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
@@ -24,8 +26,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE users SET deleted_at = NOW() WHERE id = ?")
 public class Member extends Timestamp {
-
-    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+    
+    private static final Pattern MEMBER_EMAIL_PATTERN = Pattern.compile(
             "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$");
 
     @Id
@@ -41,6 +43,10 @@ public class Member extends Timestamp {
     @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private AuthRole authRole;
+
     private String profileImageUrl;
 
     private LoginAuthenticationProvider loginAuthenticationProvider;
@@ -48,4 +54,48 @@ public class Member extends Timestamp {
     private String loginAuthenticationIdentifier;
 
     private LocalDateTime deletedAt;
+
+    @Builder
+    public Member(
+            final String nickname,
+            final String email,
+            final String password,
+            final AuthRole authRole
+    ) {
+        validateNickname(nickname);
+        validateEmail(email);
+        validatePassword(password);
+
+        this.nickname = nickname;
+        this.email = email;
+        this.password = password;
+        this.authRole = authRole;
+    }
+
+    private void validateNickname(final String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new IllegalArgumentException("닉네임은 null 또는 공백일 수 없습니다.");
+        }
+        if (nickname.length() < 2 || nickname.length() > 20) {
+            throw new IllegalArgumentException("닉네임은 2자 이상 20자 이하이어야 합니다.");
+        }
+    }
+
+    private void validateEmail(final String email) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("이메일은 null 이거나 빈 문자열일 수 없습니다.");
+        }
+        if (!MEMBER_EMAIL_PATTERN.matcher(email).matches()) {
+            throw new IllegalArgumentException("유효한 이메일 형식이 아닙니다.");
+        }
+    }
+
+    private void validatePassword(final String password) {
+        if (password == null || password.isBlank()) {
+            throw new IllegalArgumentException("비밀번호는 null 이거나 빈 문자열일 수 없습니다.");
+        }
+        if (password.length() < 6 || password.length() > 20) {
+            throw new IllegalArgumentException("비밀번호는 6자 이상 20자 이하이어야 합니다.");
+        }
+    }
 }

--- a/src/main/java/courseitda/member/domain/MemberRepository.java
+++ b/src/main/java/courseitda/member/domain/MemberRepository.java
@@ -1,0 +1,6 @@
+package courseitda.member.domain;
+
+public interface MemberRepository {
+
+    Member save(Member member);
+}

--- a/src/main/java/courseitda/member/domain/MemberRepository.java
+++ b/src/main/java/courseitda/member/domain/MemberRepository.java
@@ -1,6 +1,10 @@
 package courseitda.member.domain;
 
+import java.util.Optional;
+
 public interface MemberRepository {
 
     Member save(Member member);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/courseitda/member/infrastructure/JpaMemberRepository.java
+++ b/src/main/java/courseitda/member/infrastructure/JpaMemberRepository.java
@@ -1,0 +1,7 @@
+package courseitda.member.infrastructure;
+
+import courseitda.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaMemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/courseitda/member/infrastructure/JpaMemberRepository.java
+++ b/src/main/java/courseitda/member/infrastructure/JpaMemberRepository.java
@@ -1,7 +1,12 @@
 package courseitda.member.infrastructure;
 
-import courseitda.member.domain.Member;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import courseitda.member.domain.Member;
+
 public interface JpaMemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/courseitda/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/courseitda/member/infrastructure/MemberRepositoryImpl.java
@@ -1,9 +1,12 @@
 package courseitda.member.infrastructure;
 
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
 import courseitda.member.domain.Member;
 import courseitda.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -14,5 +17,10 @@ public class MemberRepositoryImpl implements MemberRepository {
     @Override
     public Member save(final Member member) {
         return jpaMemberRepository.save(member);
+    }
+
+    @Override
+    public Optional<Member> findByEmail(final String email) {
+        return jpaMemberRepository.findByEmail(email);
     }
 }

--- a/src/main/java/courseitda/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/courseitda/member/infrastructure/MemberRepositoryImpl.java
@@ -1,0 +1,18 @@
+package courseitda.member.infrastructure;
+
+import courseitda.member.domain.Member;
+import courseitda.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepository {
+
+    private final JpaMemberRepository jpaMemberRepository;
+
+    @Override
+    public Member save(final Member member) {
+        return jpaMemberRepository.save(member);
+    }
+}

--- a/src/main/java/courseitda/member/ui/MemberRestController.java
+++ b/src/main/java/courseitda/member/ui/MemberRestController.java
@@ -1,16 +1,18 @@
 package courseitda.member.ui;
 
-import courseitda.member.application.MemberService;
-import courseitda.member.ui.dto.request.SignUpRequest;
-import courseitda.member.ui.dto.response.SignUpResponse;
-import jakarta.validation.Valid;
 import java.net.URI;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import courseitda.member.application.MemberService;
+import courseitda.member.ui.dto.request.SignUpRequest;
+import courseitda.member.ui.dto.response.SignUpResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberRestController {
 
     private final MemberService memberService;
-    
+
     @PostMapping
     public ResponseEntity<SignUpResponse> create(@RequestBody @Valid final SignUpRequest request) {
         final var signUpResponse = memberService.create(request);

--- a/src/main/java/courseitda/member/ui/MemberRestController.java
+++ b/src/main/java/courseitda/member/ui/MemberRestController.java
@@ -1,0 +1,28 @@
+package courseitda.member.ui;
+
+import courseitda.member.application.MemberService;
+import courseitda.member.ui.dto.request.SignUpRequest;
+import courseitda.member.ui.dto.response.SignUpResponse;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberRestController {
+
+    private final MemberService memberService;
+    
+    @PostMapping
+    public ResponseEntity<SignUpResponse> create(@RequestBody @Valid final SignUpRequest request) {
+        final var signUpResponse = memberService.create(request);
+
+        return ResponseEntity.created(URI.create("/members/" + signUpResponse.id())).body(signUpResponse);
+    }
+}

--- a/src/main/java/courseitda/member/ui/dto/request/SignUpRequest.java
+++ b/src/main/java/courseitda/member/ui/dto/request/SignUpRequest.java
@@ -3,8 +3,8 @@ package courseitda.member.ui.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record SignUpRequest(
-                            @NotBlank String nickname,
-                            @NotBlank String email,
-                            @NotBlank String password
+        @NotBlank String nickname,
+        @NotBlank String email,
+        @NotBlank String password
 ) {
 }

--- a/src/main/java/courseitda/member/ui/dto/request/SignUpRequest.java
+++ b/src/main/java/courseitda/member/ui/dto/request/SignUpRequest.java
@@ -1,0 +1,10 @@
+package courseitda.member.ui.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SignUpRequest(
+                            @NotBlank String nickname,
+                            @NotBlank String email,
+                            @NotBlank String password
+) {
+}

--- a/src/main/java/courseitda/member/ui/dto/response/SignUpResponse.java
+++ b/src/main/java/courseitda/member/ui/dto/response/SignUpResponse.java
@@ -1,0 +1,18 @@
+package courseitda.member.ui.dto.response;
+
+import courseitda.member.domain.Member;
+
+public record SignUpResponse(
+        Long id,
+        String nickname,
+        String email
+) {
+
+    public static SignUpResponse from(final Member member) {
+        return new SignUpResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getEmail()
+        );
+    }
+}

--- a/src/main/java/courseitda/user/domain/LoginAuthenticationProvider.java
+++ b/src/main/java/courseitda/user/domain/LoginAuthenticationProvider.java
@@ -1,6 +1,0 @@
-package courseitda.user.domain;
-
-public enum LoginAuthenticationProvider {
-    KAKAO,
-    ;
-}

--- a/src/main/java/courseitda/workspace/domain/Workspace.java
+++ b/src/main/java/courseitda/workspace/domain/Workspace.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import courseitda.category.domain.Category;
 import courseitda.common.Timestamp;
-import courseitda.user.domain.User;
+import courseitda.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -30,7 +30,7 @@ public class Workspace extends Timestamp {
 
     @ManyToOne
     @JoinColumn(nullable = false)
-    private User user;
+    private Member member;
 
     @Column(nullable = false)
     private String title;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,9 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
     show-sql: true
+
+security:
+  jwt:
+    access-token:
+      secret-key: since-jjwt-api-0.11-secret-key-must-be-longer-than-32-bytes
+      validity-in-milliseconds: 3600000 # 1 hour


### PR DESCRIPTION
## Issues

- closed #36 

## ✔️ Check-list

- [x] : 테스트가 모두 통과되었나요?
- [x] : Merge할 브랜치를 확인했나요?

## 🗒️ Work Description
- 인증 없는 회원가입 기능 추가
- 이메일, 비밀번호 로그인 기능 추가

## 📷 (Optional) Screenshot

## 📚 (Optional) Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이메일/비밀번호 로그인 지원: JWT 발급 후 Bearer 토큰 반환
  - 회원가입 API 추가: 닉네임·이메일·비밀번호로 가입, Location 헤더 포함 응답
  - 역할 기반 접근 제어 도입 및 요청 처리 시 인증 정보 주입 지원
- 설정
  - JWT 비밀키와 액세스 토큰 만료시간(1시간) 구성 추가
- 기타
  - JWT 관련 라이브러리 의존성 추가
  - 백엔드 구성 모듈 참조 업데이트
- 스타일
  - 코드 포매터 설정 소폭 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->