### PR TITLE
feat: 워크스페이스 조회 API 추가, E2E 실패 테스트 추가

### DIFF
--- a/src/main/java/courseitda/common/exception/ErrorCode.java
+++ b/src/main/java/courseitda/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
      * 3000 Series: Category Errors
      * 4000 Series: Category Place Errors
      * 5000 Series: Member Errors
+     * 6000 Series: Place Search Errors
      * */
 
     // TEMPORARY_ERROR - 0000
@@ -242,6 +243,62 @@ public enum ErrorCode {
             "5008",
             "이미 사용중인 닉네임입니다.",
             HttpStatus.CONFLICT // 409
+    ),
+
+    //-----------------------------------------------------------------------------------
+    // 6000 Series: Place Search Errors
+    PLACE_SEARCH_KEYWORD_EMPTY(
+            "6001",
+            "검색어는 null 또는 공백일 수 없습니다.",
+            HttpStatus.BAD_REQUEST // 400
+    ),
+
+    INVALID_PLACE_SEARCH_SIZE(
+            "6002",
+            "검색 결과 개수는 1에서 15 사이여야 합니다.",
+            HttpStatus.BAD_REQUEST // 400
+    ),
+
+    SEARCHED_PLACE_NAME_EMPTY(
+            "6003",
+            "검색된 장소의 이름은 null 또는 공백일 수 없습니다.",
+            HttpStatus.BAD_GATEWAY // 502
+    ),
+
+    SEARCHED_PLACE_ADDRESS_EMPTY(
+            "6004",
+            "검색된 장소의 주소는 null 또는 공백일 수 없습니다.",
+            HttpStatus.BAD_GATEWAY // 502
+    ),
+
+    INVALID_SEARCHED_PLACE_LATITUDE(
+            "6005",
+            "검색된 장소의 위도는 -90에서 90 사이여야 합니다.",
+            HttpStatus.BAD_GATEWAY // 502
+    ),
+
+    INVALID_SEARCHED_PLACE_LONGITUDE(
+            "6006",
+            "검색된 장소의 경도는 -180에서 180 사이여야 합니다.",
+            HttpStatus.BAD_GATEWAY // 502
+    ),
+
+    KAKAO_PLACE_SEARCH_RESPONSE_NULL(
+            "6007",
+            "카카오 장소 검색 API 응답이 null입니다.",
+            HttpStatus.BAD_GATEWAY // 502
+    ),
+
+    KAKAO_PLACE_SEARCH_STATUS_CHECK_ERROR(
+            "6008",
+            "카카오 장소 검색 API 응답 상태 확인 중 오류가 발생했습니다.",
+            HttpStatus.BAD_GATEWAY // 502
+    ),
+
+    KAKAO_PLACE_SEARCH_ERROR(
+            "6009",
+            "카카오 장소 검색 API 호출 중 오류가 발생했습니다.",
+            HttpStatus.BAD_GATEWAY // 502
     ),
     ;
 

--- a/src/main/java/courseitda/member/ui/MeController.java
+++ b/src/main/java/courseitda/member/ui/MeController.java
@@ -19,12 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/me")
+@RequiresRole(authRoles = MEMBER)
 public class MeController {
 
     private final WorkspaceService workspaceService;
 
     @GetMapping("/navigator")
-    @RequiresRole(authRoles = MEMBER)
     public ResponseEntity<MemberReadNavigatorResponse> readMemberNavigator(
             final Member member
     ) {
@@ -35,7 +35,6 @@ public class MeController {
     }
 
     @GetMapping("/dropdown")
-    @RequiresRole(authRoles = MEMBER)
     public ResponseEntity<MemberReadDropdownResponse> readMemberDropdown(
             final Member member
     ) {
@@ -46,7 +45,6 @@ public class MeController {
     }
 
     @GetMapping("/profile")
-    @RequiresRole(authRoles = MEMBER)
     public ResponseEntity<MemberReadProfileResponse> readMemberProfile(
             final Member member
     ) {
@@ -57,7 +55,6 @@ public class MeController {
     }
 
     @GetMapping("/workspaces")
-    @RequiresRole(authRoles = MEMBER)
     // TODO: 페이징 고려 필요
     public ResponseEntity<WorkspacesResponse> readMyWorkspaces(final MemberAuthInfo memberAuthInfo) {
         final var workspacesResponse = workspaceService.readWorkspacesByMemberId(memberAuthInfo.id());

--- a/src/main/java/courseitda/placesearch/application/PlaceSearchService.java
+++ b/src/main/java/courseitda/placesearch/application/PlaceSearchService.java
@@ -1,5 +1,7 @@
 package courseitda.placesearch.application;
 
+import courseitda.common.exception.BusinessException;
+import courseitda.common.exception.ErrorCode;
 import courseitda.placesearch.domain.PlaceSearcher;
 import courseitda.placesearch.domain.SearchedPlace;
 import courseitda.placesearch.ui.dto.response.SearchedPlacesResponse;
@@ -15,8 +17,16 @@ public class PlaceSearchService {
     private final PlaceSearcher placeSearcher;
 
     public SearchedPlacesResponse search(final String query) {
+        validateQuery(query);
+
         final List<SearchedPlace> searchedPlaces = placeSearcher.searchPlaces(query, SEARCH_SIZE);
 
         return SearchedPlacesResponse.from(searchedPlaces);
+    }
+
+    private void validateQuery(final String query) {
+        if (query == null || query.isBlank()) {
+            throw new BusinessException(ErrorCode.PLACE_SEARCH_KEYWORD_EMPTY);
+        }
     }
 }

--- a/src/main/java/courseitda/placesearch/domain/SearchedPlace.java
+++ b/src/main/java/courseitda/placesearch/domain/SearchedPlace.java
@@ -24,25 +24,25 @@ public record SearchedPlace(
 
     private void validateName(final String name) {
         if (name == null || name.isBlank()) {
-            throw new BusinessException(ErrorCode.TEMPORARY_ERROR);
+            throw new BusinessException(ErrorCode.SEARCHED_PLACE_NAME_EMPTY);
         }
     }
 
     private void validateAddressName(final String addressName) {
         if (addressName == null || addressName.isBlank()) {
-            throw new BusinessException(ErrorCode.TEMPORARY_ERROR);
+            throw new BusinessException(ErrorCode.SEARCHED_PLACE_ADDRESS_EMPTY);
         }
     }
 
     private void validateLatitude(final double latitude) {
         if (latitude < -90 || latitude > 90) {
-            throw new BusinessException(ErrorCode.TEMPORARY_ERROR);
+            throw new BusinessException(ErrorCode.INVALID_SEARCHED_PLACE_LATITUDE);
         }
     }
 
     private void validateLongitude(final double longitude) {
         if (longitude < -180 || longitude > 180) {
-            throw new BusinessException(ErrorCode.TEMPORARY_ERROR);
+            throw new BusinessException(ErrorCode.INVALID_SEARCHED_PLACE_LONGITUDE);
         }
     }
 }

--- a/src/main/java/courseitda/placesearch/infrastructure/kakao/KakaoPlaceSearcher.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/kakao/KakaoPlaceSearcher.java
@@ -26,7 +26,7 @@ public class KakaoPlaceSearcher implements PlaceSearcher {
         );
 
         if (kakaoPlaceSearchResponse == null) {
-            throw new BusinessException(ErrorCode.TEMPORARY_ERROR);
+            throw new BusinessException(ErrorCode.KAKAO_PLACE_SEARCH_RESPONSE_NULL);
         }
 
         return kakaoPlaceSearchResponse.documents()

--- a/src/main/java/courseitda/placesearch/infrastructure/kakao/config/KakaoPlaceSearchErrorHandler.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/kakao/config/KakaoPlaceSearchErrorHandler.java
@@ -29,7 +29,7 @@ public class KakaoPlaceSearchErrorHandler implements ResponseErrorHandler {
 
             return statusCode.is4xxClientError() || statusCode.is5xxServerError();
         } catch (final IOException ioException) {
-            throw new BusinessException(ErrorCode.TEMPORARY_ERROR);
+            throw new BusinessException(ErrorCode.KAKAO_PLACE_SEARCH_STATUS_CHECK_ERROR);
         }
     }
 
@@ -43,6 +43,6 @@ public class KakaoPlaceSearchErrorHandler implements ResponseErrorHandler {
                 "카카오 장소 검색 API 오류 발생: {} ",
                 objectMapper.readValue(response.getBody(), KakaoPlaceSearchErrorResponse.class).message()
         );
-        throw new BusinessException(ErrorCode.TEMPORARY_ERROR);
+        throw new BusinessException(ErrorCode.KAKAO_PLACE_SEARCH_ERROR);
     }
 }

--- a/src/main/java/courseitda/placesearch/infrastructure/kakao/dto/request/KakaoPlaceSearchRequest.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/kakao/dto/request/KakaoPlaceSearchRequest.java
@@ -15,13 +15,13 @@ public record KakaoPlaceSearchRequest(
 
     private void validateQuery(final String query) {
         if (query == null || query.isBlank()) {
-            throw new BusinessException(ErrorCode.TEMPORARY_ERROR);
+            throw new BusinessException(ErrorCode.PLACE_SEARCH_KEYWORD_EMPTY);
         }
     }
 
     private void validateSize(final Integer size) {
         if (size == null || size < 1 || size > 15) {
-            throw new BusinessException(ErrorCode.TEMPORARY_ERROR);
+            throw new BusinessException(ErrorCode.INVALID_PLACE_SEARCH_SIZE);
         }
     }
 }

--- a/src/main/java/courseitda/workspace/application/CategoryService.java
+++ b/src/main/java/courseitda/workspace/application/CategoryService.java
@@ -91,11 +91,9 @@ public class CategoryService {
             final Long categoryId,
             final CategoryUpdateRequest request
     ) {
-        final var workspace = getWorkspaceByIdentifier(workspaceIdentifier);
-        workspace.validateOwnership(memberAuthInfo.id());
-
         final var category = getCategoryById(categoryId);
-        validateCategoryBelongsToWorkspace(workspace, category);
+        category.validateOwnership(memberAuthInfo.id());
+        validateCategoryBelongsToWorkspace(getWorkspaceByIdentifier(workspaceIdentifier), category);
 
         category.updateNameAndColor(request.name(), request.color());
         return CategoryUpdateResponse.from(category);
@@ -107,11 +105,9 @@ public class CategoryService {
             final String workspaceIdentifier,
             final Long categoryId
     ) {
-        final var workspace = getWorkspaceByIdentifier(workspaceIdentifier);
-        workspace.validateOwnership(memberAuthInfo.id());
-
         final var category = getCategoryById(categoryId);
-        validateCategoryBelongsToWorkspace(workspace, category);
+        category.validateOwnership(memberAuthInfo.id());
+        validateCategoryBelongsToWorkspace(getWorkspaceByIdentifier(workspaceIdentifier), category);
 
         categoryRepository.delete(category);
     }
@@ -122,11 +118,9 @@ public class CategoryService {
             final String workspaceIdentifier,
             final Long categoryId
     ) {
-        final var workspace = getWorkspaceByIdentifier(workspaceIdentifier);
-        workspace.validateOwnership(memberAuthInfo.id());
-
         final var category = getCategoryById(categoryId);
-        validateCategoryBelongsToWorkspace(workspace, category);
+        category.validateOwnership(memberAuthInfo.id());
+        validateCategoryBelongsToWorkspace(getWorkspaceByIdentifier(workspaceIdentifier), category);
 
         return CategoryResponse.from(category);
     }

--- a/src/main/java/courseitda/workspace/application/WorkspaceService.java
+++ b/src/main/java/courseitda/workspace/application/WorkspaceService.java
@@ -9,6 +9,7 @@ import courseitda.workspace.domain.WorkspaceRepository;
 import courseitda.workspace.ui.dto.request.WorkspaceCreateRequest;
 import courseitda.workspace.ui.dto.request.WorkspaceUpdateRequest;
 import courseitda.workspace.ui.dto.response.WorkspaceCreateResponse;
+import courseitda.workspace.ui.dto.response.WorkspaceReadResponse;
 import courseitda.workspace.ui.dto.response.WorkspaceUpdateResponse;
 import courseitda.workspace.ui.dto.response.WorkspacesResponse;
 import lombok.RequiredArgsConstructor;
@@ -63,9 +64,12 @@ public class WorkspaceService {
         return WorkspacesResponse.from(workspaceRepository.findAllByOwnerId(memberId));
     }
 
-    private Workspace getById(final Long workspaceId) {
-        return workspaceRepository.findById(workspaceId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.WORKSPACE_NOT_FOUND));
+    @Transactional(readOnly = true)
+    public WorkspaceReadResponse readWorkspace(final MemberAuthInfo memberAuthInfo, final String workspaceIdentifier) {
+        final var workspace = getByIdentifier(workspaceIdentifier);
+        workspace.validateOwnership(memberAuthInfo.id());
+
+        return WorkspaceReadResponse.from(workspace);
     }
 
     private Workspace getByIdentifier(final String identifier) {

--- a/src/main/java/courseitda/workspace/ui/WorkspaceController.java
+++ b/src/main/java/courseitda/workspace/ui/WorkspaceController.java
@@ -8,12 +8,14 @@ import courseitda.workspace.application.WorkspaceService;
 import courseitda.workspace.ui.dto.request.WorkspaceCreateRequest;
 import courseitda.workspace.ui.dto.request.WorkspaceUpdateRequest;
 import courseitda.workspace.ui.dto.response.WorkspaceCreateResponse;
+import courseitda.workspace.ui.dto.response.WorkspaceReadResponse;
 import courseitda.workspace.ui.dto.response.WorkspaceUpdateResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -79,5 +81,21 @@ public class WorkspaceController {
         workspaceService.deleteWorkspace(memberAuthInfo, workspaceIdentifier);
 
         return ResponseEntity.noContent().build();
+    }
+
+    // 워크스페이스 조회
+    @GetMapping("/{workspaceIdentifier}")
+    public ResponseEntity<WorkspaceReadResponse> readWorkspace(
+            final MemberAuthInfo memberAuthInfo,
+            @PathVariable final String workspaceIdentifier
+    ) {
+        // ✅ 200 OK	        워크스페이스 조회 성공
+        // ✅ 401 Unauthorized	토큰 누락 또는 유효하지 않은 토큰 -> MemberAuthInfo 받아오는 과정에서 알아서 처리
+        // ✅ 403 Forbidden	    유효한 토큰을 갖고 있지만, 해당 워크스페이스의 조회 권한이 없음 -> 워크스페이스 소유자 여부 예외 처리
+        // ✅ 404 Not Found	    워크스페이스 ID가 존재하지 않음 -> findById 예외 처리
+
+        final WorkspaceReadResponse response = workspaceService.readWorkspace(memberAuthInfo, workspaceIdentifier);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceReadResponse.java
+++ b/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceReadResponse.java
@@ -1,0 +1,16 @@
+package courseitda.workspace.ui.dto.response;
+
+import courseitda.workspace.domain.Workspace;
+
+public record WorkspaceReadResponse(
+        String identifier,
+        String title
+) {
+
+    public static WorkspaceReadResponse from(final Workspace workspace) {
+        return new WorkspaceReadResponse(
+                workspace.getIdentifier(),
+                workspace.getTitle()
+        );
+    }
+}

--- a/src/test/java/courseitda/auth/ui/AuthControllerTest.java
+++ b/src/test/java/courseitda/auth/ui/AuthControllerTest.java
@@ -6,12 +6,13 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 import courseitda.auth.ui.dto.request.LoginRequest;
 import courseitda.auth.ui.dto.response.LoginResponse;
+import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.MemberFixture;
 import courseitda.member.ui.dto.request.SignUpRequest;
 import io.restassured.RestAssured;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -20,7 +21,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
-@Transactional
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class AuthControllerTest {
@@ -33,13 +33,89 @@ class AuthControllerTest {
         RestAssured.port = port;
     }
 
-    @Test
-    @DisplayName("로그인에 성공한다")
-    void login_success() {
-        // given
-        final String email = MemberFixture.anyEmail();
-        final String password = MemberFixture.anyPassword();
-        final String nickname = MemberFixture.anyNickname();
+    @Nested
+    @DisplayName("로그인 성공 시나리오")
+    class LoginSuccessScenarios {
+
+        @Test
+        @DisplayName("로그인에 성공한다")
+        void login_success() {
+            // given
+            final String email = MemberFixture.anyEmail();
+            final String password = MemberFixture.anyPassword();
+            final String nickname = MemberFixture.anyNickname();
+
+            signUp(nickname, email, password);
+
+            final LoginRequest loginRequest = new LoginRequest(email, password);
+
+            // when
+            final LoginResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(loginRequest)
+                    .when()
+                    .post("/api/auth/login")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(LoginResponse.class);
+
+            // then
+            assertThat(response.tokenType()).isEqualTo("Bearer");
+            assertThat(response.accessToken()).isNotNull();
+            assertThat(response.accessToken()).isNotEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 실패 시나리오")
+    class LoginFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 이메일로 로그인 시 실패한다")
+        void login_fail_memberNotFoundByEmail() {
+            // given
+            final String nonExistentEmail = MemberFixture.anyEmail();
+            final String password = MemberFixture.anyPassword();
+            final LoginRequest loginRequest = new LoginRequest(nonExistentEmail, password);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(loginRequest)
+                    .when()
+                    .post("/api/auth/login")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.MEMBER_NOT_FOUND_BY_EMAIL.getCode()));
+        }
+
+        @Test
+        @DisplayName("잘못된 비밀번호로 로그인 시 실패한다")
+        void login_fail_incorrectPassword() {
+            // given
+            final String email = MemberFixture.anyEmail();
+            final String password = MemberFixture.anyPassword();
+            final String nickname = MemberFixture.anyNickname();
+
+            signUp(nickname, email, password);
+
+            final String wrongPassword = "wrongPassword123!";
+            final LoginRequest loginRequest = new LoginRequest(email, wrongPassword);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(loginRequest)
+                    .when()
+                    .post("/api/auth/login")
+                    .then()
+                    .statusCode(HttpStatus.UNAUTHORIZED.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.INCORRECT_PASSWORD.getCode()));
+        }
+    }
+
+    private void signUp(final String nickname, final String email, final String password) {
         final SignUpRequest signUpRequest = new SignUpRequest(nickname, email, password);
 
         given()
@@ -49,23 +125,5 @@ class AuthControllerTest {
                 .post("/api/members")
                 .then()
                 .statusCode(HttpStatus.CREATED.value());
-
-        final LoginRequest loginRequest = new LoginRequest(email, password);
-
-        // when
-        final LoginResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(loginRequest)
-                .when()
-                .post("/api/auth/login")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(LoginResponse.class);
-
-        // then
-        assertThat(response.tokenType()).isEqualTo("Bearer");
-        assertThat(response.accessToken()).isNotNull();
-        assertThat(response.accessToken()).isNotEmpty();
     }
 }

--- a/src/test/java/courseitda/member/ui/MeControllerTest.java
+++ b/src/test/java/courseitda/member/ui/MeControllerTest.java
@@ -6,19 +6,20 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 import courseitda.auth.ui.dto.request.LoginRequest;
 import courseitda.auth.ui.dto.response.LoginResponse;
+import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.MemberFixture;
 import courseitda.member.ui.dto.request.SignUpRequest;
 import courseitda.member.ui.dto.response.MemberReadDropdownResponse;
 import courseitda.member.ui.dto.response.MemberReadNavigatorResponse;
 import courseitda.member.ui.dto.response.MemberReadProfileResponse;
+import courseitda.workspace.domain.WorkspaceFixture;
 import courseitda.workspace.ui.dto.request.WorkspaceCreateRequest;
+import courseitda.workspace.ui.dto.response.WorkspaceCreateResponse;
 import courseitda.workspace.ui.dto.response.WorkspacesResponse;
-import courseitda.workspace.ui.dto.response.WorkspacesResponse.WorkspaceResponse;
 import io.restassured.RestAssured;
-import jakarta.transaction.Transactional;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -28,7 +29,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
-@Transactional
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class MeControllerTest {
@@ -41,209 +41,181 @@ class MeControllerTest {
         RestAssured.port = port;
     }
 
-    @Test
-    @DisplayName("회원 정보(네비게이터 뷰) 조회에 성공한다")
-    void readMemberNavigator_success() {
-        // given
-        final String nickname = MemberFixture.anyNickname();
-        final String email = MemberFixture.anyEmail();
-        final String password = MemberFixture.anyPassword();
-        final SignUpRequest signUpRequest = new SignUpRequest(nickname, email, password);
+    @Nested
+    @DisplayName("내 네비게이터 정보 조회 성공 시나리오")
+    class ReadMemberNavigatorSuccessScenarios {
 
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(signUpRequest)
-                .when()
-                .post("/api/members")
-                .then()
-                .statusCode(HttpStatus.CREATED.value());
+        @Test
+        @DisplayName("내 네비게이터 정보 조회에 성공한다")
+        void readMemberNavigator_success() {
+            // given
+            final String accessToken = signUpAndLogin();
 
-        final LoginRequest loginRequest = new LoginRequest(email, password);
-        final LoginResponse loginResponse = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(loginRequest)
-                .when()
-                .post("/api/auth/login")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(LoginResponse.class);
-
-        final String accessToken = loginResponse.tokenType() + " " + loginResponse.accessToken();
-
-        // when
-        final MemberReadNavigatorResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when()
-                .get("/api/me/navigator")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(MemberReadNavigatorResponse.class);
-
-        // then
-        assertThat(response.nickname()).isEqualTo(nickname);
-    }
-
-    @Test
-    @DisplayName("회원 정보(드롭다운 뷰) 조회에 성공한다")
-    void readMemberDropdown_success() {
-        // given
-        final String nickname = MemberFixture.anyNickname();
-        final String email = MemberFixture.anyEmail();
-        final String password = MemberFixture.anyPassword();
-        final SignUpRequest signUpRequest = new SignUpRequest(nickname, email, password);
-
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(signUpRequest)
-                .when()
-                .post("/api/members")
-                .then()
-                .statusCode(HttpStatus.CREATED.value());
-
-        final LoginRequest loginRequest = new LoginRequest(email, password);
-        final LoginResponse loginResponse = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(loginRequest)
-                .when()
-                .post("/api/auth/login")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(LoginResponse.class);
-
-        final String accessToken = loginResponse.tokenType() + " " + loginResponse.accessToken();
-
-        // when
-        final MemberReadDropdownResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when()
-                .get("/api/me/dropdown")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(MemberReadDropdownResponse.class);
-
-        // then
-        assertThat(response.nickname()).isEqualTo(nickname);
-        assertThat(response.email()).isEqualTo(email);
-    }
-
-    @Test
-    @DisplayName("회원 정보(프로필) 조회에 성공한다")
-    void readMemberProfile_success() {
-        // given
-        final String nickname = MemberFixture.anyNickname();
-        final String email = MemberFixture.anyEmail();
-        final String password = MemberFixture.anyPassword();
-        final SignUpRequest signUpRequest = new SignUpRequest(nickname, email, password);
-
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(signUpRequest)
-                .when()
-                .post("/api/members")
-                .then()
-                .statusCode(HttpStatus.CREATED.value());
-
-        final LoginRequest loginRequest = new LoginRequest(email, password);
-        final LoginResponse loginResponse = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(loginRequest)
-                .when()
-                .post("/api/auth/login")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(LoginResponse.class);
-
-        final String accessToken = loginResponse.tokenType() + " " + loginResponse.accessToken();
-
-        // when
-        final MemberReadProfileResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when()
-                .get("/api/me/profile")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(MemberReadProfileResponse.class);
-
-        // then
-        assertThat(response.nickName()).isEqualTo(nickname);
-        assertThat(response.email()).isEqualTo(email);
-    }
-
-    @Test
-    @DisplayName("내 워크스페이스 목록 조회에 성공한다")
-    void readMyWorkspaces_success() {
-        // given
-        final String nickname = MemberFixture.anyNickname();
-        final String email = MemberFixture.anyEmail();
-        final String password = MemberFixture.anyPassword();
-        final SignUpRequest signUpRequest = new SignUpRequest(nickname, email, password);
-
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(signUpRequest)
-                .when()
-                .post("/api/members")
-                .then()
-                .statusCode(HttpStatus.CREATED.value());
-
-        final LoginRequest loginRequest = new LoginRequest(email, password);
-        final LoginResponse loginResponse = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(loginRequest)
-                .when()
-                .post("/api/auth/login")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(LoginResponse.class);
-
-        final String accessToken = loginResponse.tokenType() + " " + loginResponse.accessToken();
-
-        // 워크스페이스 3개 생성
-        final List<WorkspaceCreateRequest> workspaceCreateRequests = List.of(
-                new WorkspaceCreateRequest("워크스페이스1"),
-                new WorkspaceCreateRequest("워크스페이스2"),
-                new WorkspaceCreateRequest("워크스페이스3")
-        );
-
-        workspaceCreateRequests.forEach(workspaceCreateRequest -> {
-            given()
+            // when
+            final MemberReadNavigatorResponse response = given()
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .header(HttpHeaders.AUTHORIZATION, accessToken)
-                    .body(workspaceCreateRequest)
                     .when()
-                    .post("/api/workspaces")
+                    .get("/api/me/navigator")
                     .then()
-                    .statusCode(HttpStatus.CREATED.value());
-        });
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(MemberReadNavigatorResponse.class);
 
-        // when
-        final WorkspacesResponse response = given()
+            // then
+            assertThat(response.nickname()).isNotNull();
+        }
+    }
+
+
+    @Nested
+    @DisplayName("내 드롭다운 정보 조회 성공 시나리오")
+    class ReadMemberDropdownSuccessScenarios {
+
+        @Test
+        @DisplayName("내 드롭다운 정보 조회에 성공한다")
+        void readMemberDropdown_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+
+            // when
+            final MemberReadDropdownResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/me/dropdown")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(MemberReadDropdownResponse.class);
+
+            // then
+            assertThat(response.nickname()).isNotNull();
+            assertThat(response.email()).isNotNull();
+        }
+    }
+
+
+    @Nested
+    @DisplayName("내 프로필 정보 조회 성공 시나리오")
+    class ReadMemberProfileSuccessScenarios {
+
+        @Test
+        @DisplayName("내 프로필 정보 조회에 성공한다")
+        void readMemberProfile_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+
+            // when
+            final MemberReadProfileResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/me/profile")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(MemberReadProfileResponse.class);
+
+            // then
+            assertThat(response.nickName()).isNotNull();
+            assertThat(response.email()).isNotNull();
+        }
+    }
+
+
+    @Nested
+    @DisplayName("내 워크스페이스 목록 조회 성공 시나리오")
+    class ReadMyWorkspacesSuccessScenarios {
+
+        @Test
+        @DisplayName("내 워크스페이스 목록 조회에 성공한다")
+        void readMyWorkspaces_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            createWorkspace(accessToken);
+            createWorkspace(accessToken);
+
+            // when
+            final WorkspacesResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/me/workspaces")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspacesResponse.class);
+
+            // then
+            assertThat(response.workspaces()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("워크스페이스가 없는 경우 빈 목록이 반환된다")
+        void readMyWorkspaces_success_emptyList() {
+            // given
+            final String accessToken = signUpAndLogin();
+
+            // when
+            final WorkspacesResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/me/workspaces")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspacesResponse.class);
+
+            // then
+            assertThat(response.workspaces()).isEmpty();
+        }
+    }
+
+
+    private String signUpAndLogin() {
+        final String email = MemberFixture.anyEmail();
+        final String password = MemberFixture.anyPassword();
+        final String nickname = MemberFixture.anyNickname();
+        final SignUpRequest signUpRequest = new SignUpRequest(nickname, email, password);
+
+        given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(signUpRequest)
                 .when()
-                .get("/api/me/workspaces")
+                .post("/api/members")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+
+        final LoginRequest loginRequest = new LoginRequest(email, password);
+        final LoginResponse loginResponse = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(loginRequest)
+                .when()
+                .post("/api/auth/login")
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
-                .as(WorkspacesResponse.class);
+                .as(LoginResponse.class);
 
-        // then
-        assertThat(response.workspaces()).hasSize(3);
-        assertThat(
-                response.workspaces()
-                        .stream()
-                        .map(WorkspaceResponse::title)
-                        .toList()
-        ).containsExactlyInAnyOrder("워크스페이스1", "워크스페이스2", "워크스페이스3");
+        return loginResponse.tokenType() + " " + loginResponse.accessToken();
+    }
+
+    private String createWorkspace(final String accessToken) {
+        final String title = WorkspaceFixture.anyTitle();
+        final WorkspaceCreateRequest request = new WorkspaceCreateRequest(title);
+
+        return given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(request)
+                .when()
+                .post("/api/workspaces")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract()
+                .as(WorkspaceCreateResponse.class)
+                .identifier();
     }
 }

--- a/src/test/java/courseitda/member/ui/MeControllerTest.java
+++ b/src/test/java/courseitda/member/ui/MeControllerTest.java
@@ -67,7 +67,6 @@ class MeControllerTest {
         }
     }
 
-
     @Nested
     @DisplayName("내 드롭다운 정보 조회 성공 시나리오")
     class ReadMemberDropdownSuccessScenarios {
@@ -95,7 +94,6 @@ class MeControllerTest {
         }
     }
 
-
     @Nested
     @DisplayName("내 프로필 정보 조회 성공 시나리오")
     class ReadMemberProfileSuccessScenarios {
@@ -122,7 +120,6 @@ class MeControllerTest {
             assertThat(response.email()).isNotNull();
         }
     }
-
 
     @Nested
     @DisplayName("내 워크스페이스 목록 조회 성공 시나리오")
@@ -172,7 +169,6 @@ class MeControllerTest {
             assertThat(response.workspaces()).isEmpty();
         }
     }
-
 
     private String signUpAndLogin() {
         final String email = MemberFixture.anyEmail();

--- a/src/test/java/courseitda/member/ui/MemberControllerTest.java
+++ b/src/test/java/courseitda/member/ui/MemberControllerTest.java
@@ -4,13 +4,14 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
+import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.MemberFixture;
 import courseitda.member.ui.dto.request.SignUpRequest;
 import courseitda.member.ui.dto.response.SignUpResponse;
 import io.restassured.RestAssured;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -19,7 +20,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
-@Transactional
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class MemberControllerTest {
@@ -32,29 +32,101 @@ class MemberControllerTest {
         RestAssured.port = port;
     }
 
-    @Test
-    @DisplayName("회원가입에 성공한다")
-    void signup_success() {
-        // given
-        final String nickname = MemberFixture.anyNickname();
-        final String email = MemberFixture.anyEmail();
-        final String password = MemberFixture.anyPassword();
-        final SignUpRequest request = new SignUpRequest(nickname, email, password);
+    @Nested
+    @DisplayName("회원가입 성공 시나리오")
+    class SignUpSuccessScenarios {
 
-        // when
-        final SignUpResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(request)
-                .when()
-                .post("/api/members")
-                .then()
-                .statusCode(HttpStatus.CREATED.value())
-                .extract()
-                .as(SignUpResponse.class);
+        @Test
+        @DisplayName("회원가입에 성공한다")
+        void signup_success() {
+            // given
+            final String nickname = MemberFixture.anyNickname();
+            final String email = MemberFixture.anyEmail();
+            final String password = MemberFixture.anyPassword();
+            final SignUpRequest request = new SignUpRequest(nickname, email, password);
 
-        // then
-        assertThat(response.id()).isNotNull();
-        assertThat(response.nickname()).isEqualTo(nickname);
-        assertThat(response.email()).isEqualTo(email);
+            // when
+            final SignUpResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .when()
+                    .post("/api/members")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .extract()
+                    .as(SignUpResponse.class);
+
+            // then
+            assertThat(response.id()).isNotNull();
+            assertThat(response.nickname()).isEqualTo(nickname);
+            assertThat(response.email()).isEqualTo(email);
+        }
+    }
+
+    @Nested
+    @DisplayName("회원가입 실패 시나리오")
+    class SignUpFailureScenarios {
+
+        @Test
+        @DisplayName("중복된 이메일로 회원가입 시 실패한다")
+        void signup_fail_duplicateEmail() {
+            // given
+            final String nickname = MemberFixture.anyNickname();
+            final String email = MemberFixture.anyEmail();
+            final String password = MemberFixture.anyPassword();
+            final SignUpRequest request = new SignUpRequest(nickname, email, password);
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .when()
+                    .post("/api/members")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value());
+
+            final String anotherNickname = MemberFixture.anyNickname();
+            final SignUpRequest duplicateEmailRequest = new SignUpRequest(anotherNickname, email, password);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(duplicateEmailRequest)
+                    .when()
+                    .post("/api/members")
+                    .then()
+                    .statusCode(HttpStatus.CONFLICT.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.DUPLICATE_EMAIL.getCode()));
+        }
+
+        @Test
+        @DisplayName("중복된 닉네임으로 회원가입 시 실패한다")
+        void signup_fail_duplicateNickname() {
+            // given
+            final String nickname = MemberFixture.anyNickname();
+            final String email = MemberFixture.anyEmail();
+            final String password = MemberFixture.anyPassword();
+            final SignUpRequest request = new SignUpRequest(nickname, email, password);
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .when()
+                    .post("/api/members")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value());
+
+            final String anotherEmail = MemberFixture.anyEmail();
+            final SignUpRequest duplicateNicknameRequest = new SignUpRequest(nickname, anotherEmail, password);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(duplicateNicknameRequest)
+                    .when()
+                    .post("/api/members")
+                    .then()
+                    .statusCode(HttpStatus.CONFLICT.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.DUPLICATE_NICKNAME.getCode()));
+        }
     }
 }

--- a/src/test/java/courseitda/placesearch/ui/PlaceSearchControllerTest.java
+++ b/src/test/java/courseitda/placesearch/ui/PlaceSearchControllerTest.java
@@ -110,6 +110,28 @@ class PlaceSearchControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("장소 검색 실패 시나리오")
+    class SearchPlacesFailureScenarios {
+
+        @Test
+        @DisplayName("검색어가 null이거나 공백인 경우 장소 검색에 실패한다")
+        void searchPlaces_fail_emptyKeyword() {
+            // given
+            final String accessToken = signUpAndLogin();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .queryParam("keyword", "   ")
+                    .when()
+                    .get("/api/places/search")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value());
+        }
+    }
+
     private String signUpAndLogin() {
         final String nickname = MemberFixture.anyNickname();
         final String email = MemberFixture.anyEmail();

--- a/src/test/java/courseitda/placesearch/ui/PlaceSearchControllerTest.java
+++ b/src/test/java/courseitda/placesearch/ui/PlaceSearchControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 
 import courseitda.auth.ui.dto.request.LoginRequest;
 import courseitda.auth.ui.dto.response.LoginResponse;
+import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.MemberFixture;
 import courseitda.member.ui.dto.request.SignUpRequest;
 import courseitda.placesearch.domain.PlaceSearcher;
@@ -128,7 +129,8 @@ class PlaceSearchControllerTest {
                     .when()
                     .get("/api/places/search")
                     .then()
-                    .statusCode(HttpStatus.BAD_REQUEST.value());
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.PLACE_SEARCH_KEYWORD_EMPTY.getCode()));
         }
     }
 

--- a/src/test/java/courseitda/placesearch/ui/PlaceSearchControllerTest.java
+++ b/src/test/java/courseitda/placesearch/ui/PlaceSearchControllerTest.java
@@ -15,9 +15,11 @@ import courseitda.placesearch.domain.SearchedPlace;
 import courseitda.placesearch.ui.dto.response.SearchedPlacesResponse;
 import io.restassured.RestAssured;
 import jakarta.transaction.Transactional;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -40,12 +42,75 @@ class PlaceSearchControllerTest {
     @MockitoBean
     private PlaceSearcher mockPlaceSearcher;
 
-    private String accessToken;
-
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+    }
 
+    @Nested
+    @DisplayName("장소 검색 성공 시나리오")
+    class SearchPlacesSuccessScenarios {
+
+        @Test
+        @DisplayName("장소 검색에 성공한다")
+        void searchPlaces_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final List<SearchedPlace> mockSearchedPlaces = List.of(
+                    new SearchedPlace("스타벅스 강남점", "서울 강남구 역삼동 123-45", "서울 강남구 테헤란로 123", 37.498095, 127.027610),
+                    new SearchedPlace("스타벅스 역삼점", "서울 강남구 역삼동 678-90", "서울 강남구 테헤란로 456", 37.500123, 127.030456),
+                    new SearchedPlace("스타벅스 선릉점", "서울 강남구 역삼동 234-56", "서울 강남구 테헤란로 789", 37.504567, 127.049123)
+            );
+            given(mockPlaceSearcher.searchPlaces(anyString(), anyInt()))
+                    .willReturn(mockSearchedPlaces);
+
+            // when
+            final SearchedPlacesResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .queryParam("keyword", "스타벅스")
+                    .when()
+                    .get("/api/places/search")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(SearchedPlacesResponse.class);
+
+            // then
+            assertThat(response.searchedPlaces()).hasSize(3);
+            assertThat(response.searchedPlaces().get(0).name()).isEqualTo("스타벅스 강남점");
+            assertThat(response.searchedPlaces().get(0).addressName()).isEqualTo("서울 강남구 역삼동 123-45");
+            assertThat(response.searchedPlaces().get(0).roadAddressName()).isEqualTo("서울 강남구 테헤란로 123");
+            assertThat(response.searchedPlaces().get(0).latitude()).isEqualTo(37.498095);
+            assertThat(response.searchedPlaces().get(0).longitude()).isEqualTo(127.027610);
+        }
+
+        @Test
+        @DisplayName("검색 결과가 없는 경우 빈 목록이 반환된다")
+        void searchPlaces_success_emptyResult() {
+            // given
+            final String accessToken = signUpAndLogin();
+            given(mockPlaceSearcher.searchPlaces(anyString(), anyInt()))
+                    .willReturn(Collections.emptyList());
+
+            // when
+            final SearchedPlacesResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .queryParam("keyword", "존재하지않는장소")
+                    .when()
+                    .get("/api/places/search")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(SearchedPlacesResponse.class);
+
+            // then
+            assertThat(response.searchedPlaces()).isEmpty();
+        }
+    }
+
+    private String signUpAndLogin() {
         final String nickname = MemberFixture.anyNickname();
         final String email = MemberFixture.anyEmail();
         final String password = MemberFixture.anyPassword();
@@ -70,39 +135,6 @@ class PlaceSearchControllerTest {
                 .extract()
                 .as(LoginResponse.class);
 
-        accessToken = loginResponse.tokenType() + " " + loginResponse.accessToken();
-    }
-
-    @Test
-    @DisplayName("장소 검색에 성공한다")
-    void searchPlaces_success() {
-        // given
-        final List<SearchedPlace> mockSearchedPlaces = List.of(
-                new SearchedPlace("스타벅스 강남점", "서울 강남구 역삼동 123-45", "서울 강남구 테헤란로 123", 37.498095, 127.027610),
-                new SearchedPlace("스타벅스 역삼점", "서울 강남구 역삼동 678-90", "서울 강남구 테헤란로 456", 37.500123, 127.030456),
-                new SearchedPlace("스타벅스 선릉점", "서울 강남구 역삼동 234-56", "서울 강남구 테헤란로 789", 37.504567, 127.049123)
-        );
-        given(mockPlaceSearcher.searchPlaces(anyString(), anyInt()))
-                .willReturn(mockSearchedPlaces);
-
-        // when
-        final SearchedPlacesResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .queryParam("keyword", "스타벅스")
-                .when()
-                .get("/api/places/search")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(SearchedPlacesResponse.class);
-
-        // then
-        assertThat(response.searchedPlaces()).hasSize(3);
-        assertThat(response.searchedPlaces().get(0).name()).isEqualTo("스타벅스 강남점");
-        assertThat(response.searchedPlaces().get(0).addressName()).isEqualTo("서울 강남구 역삼동 123-45");
-        assertThat(response.searchedPlaces().get(0).roadAddressName()).isEqualTo("서울 강남구 테헤란로 123");
-        assertThat(response.searchedPlaces().get(0).latitude()).isEqualTo(37.498095);
-        assertThat(response.searchedPlaces().get(0).longitude()).isEqualTo(127.027610);
+        return loginResponse.tokenType() + " " + loginResponse.accessToken();
     }
 }

--- a/src/test/java/courseitda/workspace/ui/CategoryControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/CategoryControllerTest.java
@@ -314,7 +314,7 @@ class CategoryControllerTest {
                     .patch("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
                     .then()
                     .statusCode(HttpStatus.FORBIDDEN.value())
-                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN.getCode()));
         }
 
         @Test
@@ -407,7 +407,7 @@ class CategoryControllerTest {
                     .delete("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
                     .then()
                     .statusCode(HttpStatus.FORBIDDEN.value())
-                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN.getCode()));
         }
 
         @Test

--- a/src/test/java/courseitda/workspace/ui/CategoryControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/CategoryControllerTest.java
@@ -314,7 +314,7 @@ class CategoryControllerTest {
                     .patch("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
                     .then()
                     .statusCode(HttpStatus.FORBIDDEN.value())
-                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN.getCode()));
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
         }
 
         @Test
@@ -407,7 +407,7 @@ class CategoryControllerTest {
                     .delete("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
                     .then()
                     .statusCode(HttpStatus.FORBIDDEN.value())
-                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN.getCode()));
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
         }
 
         @Test

--- a/src/test/java/courseitda/workspace/ui/CategoryControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/CategoryControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 import courseitda.auth.ui.dto.request.LoginRequest;
 import courseitda.auth.ui.dto.response.LoginResponse;
+import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.MemberFixture;
 import courseitda.member.ui.dto.request.SignUpRequest;
 import courseitda.workspace.domain.CategoryFixture;
@@ -25,6 +26,7 @@ import io.restassured.RestAssured;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -46,168 +48,558 @@ class CategoryControllerTest {
         RestAssured.port = port;
     }
 
-    @Test
-    @DisplayName("카테고리 생성에 성공한다")
-    void createCategory_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
+    @Nested
+    @DisplayName("카테고리 생성 성공 시나리오")
+    class CreateCategorySuccessScenarios {
 
-        final String name = CategoryFixture.anyName();
-        final String color = CategoryFixture.anyColor();
-        final CategoryCreateRequest request = new CategoryCreateRequest(name, color);
+        @Test
+        @DisplayName("카테고리 생성에 성공한다")
+        void createCategory_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
 
-        // when
-        final CategoryCreateResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(request)
-                .when()
-                .post("/api/workspaces/" + workspaceIdentifier + "/categories")
-                .then()
-                .statusCode(HttpStatus.CREATED.value())
-                .extract()
-                .as(CategoryCreateResponse.class);
+            final String name = CategoryFixture.anyName();
+            final String color = CategoryFixture.anyColor();
+            final CategoryCreateRequest request = new CategoryCreateRequest(name, color);
 
-        // then
-        assertThat(response.id()).isNotNull();
-        assertThat(response.name()).isEqualTo(name);
-        assertThat(response.color()).isEqualTo(color);
-        assertThat(response.sequence()).isEqualTo(1);
+            // when
+            final CategoryCreateResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/workspaces/" + workspaceIdentifier + "/categories")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .extract()
+                    .as(CategoryCreateResponse.class);
+
+            // then
+            assertThat(response.id()).isNotNull();
+            assertThat(response.name()).isEqualTo(name);
+            assertThat(response.color()).isEqualTo(color);
+            assertThat(response.sequence()).isEqualTo(1);
+        }
     }
 
-    @Test
-    @DisplayName("카테고리 순서 변경에 성공한다")
-    void updateCategorySequence_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
+    @Nested
+    @DisplayName("카테고리 생성 실패 시나리오")
+    class CreateCategoryFailureScenarios {
 
-        final CategoryCreateResponse category1 = createCategory(accessToken, workspaceIdentifier);
-        final CategoryCreateResponse category2 = createCategory(accessToken, workspaceIdentifier);
+        @Test
+        @DisplayName("존재하지 않는 워크스페이스에 카테고리 생성 시 실패한다")
+        void createCategory_fail_workspaceNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String nonExistentIdentifier = "non-existent-identifier";
 
-        final List<CategorySequenceRequest> sequenceRequests = List.of(
-                new CategorySequenceRequest(category1.id(), 2),
-                new CategorySequenceRequest(category2.id(), 1)
-        );
-        final CategoryReorderRequest request = new CategoryReorderRequest(sequenceRequests);
+            final String name = CategoryFixture.anyName();
+            final String color = CategoryFixture.anyColor();
+            final CategoryCreateRequest request = new CategoryCreateRequest(name, color);
 
-        // when
-        final CategoryReorderResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(request)
-                .when()
-                .post("/api/workspaces/" + workspaceIdentifier + "/categories/reorder")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(CategoryReorderResponse.class);
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/workspaces/" + nonExistentIdentifier + "/categories")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_NOT_FOUND.getCode()));
+        }
 
-        // then
-        assertThat(response.categorySequenceResponses()).hasSize(2);
-        assertThat(response.categorySequenceResponses()).extracting("id")
-                .containsExactlyInAnyOrder(category1.id(), category2.id());
+        @Test
+        @DisplayName("다른 사용자의 워크스페이스에 카테고리 생성 시 실패한다")
+        void createCategory_fail_workspaceModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+
+            final String otherUser = signUpAndLogin();
+            final String name = CategoryFixture.anyName();
+            final String color = CategoryFixture.anyColor();
+            final CategoryCreateRequest request = new CategoryCreateRequest(name, color);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .body(request)
+                    .when()
+                    .post("/api/workspaces/" + workspaceIdentifier + "/categories")
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN.getCode()));
+        }
     }
 
-    @Test
-    @DisplayName("카테고리 수정에 성공한다")
-    void updateCategory_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
-        final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier);
+    @Nested
+    @DisplayName("카테고리 순서 변경 성공 시나리오")
+    class UpdateCategorySequenceSuccessScenarios {
 
-        final String newName = CategoryFixture.anyName();
-        final String newColor = "#123456";
-        final CategoryUpdateRequest request = new CategoryUpdateRequest(newName, newColor);
+        @Test
+        @DisplayName("카테고리 순서 변경에 성공한다")
+        void updateCategorySequence_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
 
-        // when
-        final CategoryUpdateResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(request)
-                .when()
-                .patch("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(CategoryUpdateResponse.class);
+            final CategoryCreateResponse category1 = createCategory(accessToken, workspaceIdentifier);
+            final CategoryCreateResponse category2 = createCategory(accessToken, workspaceIdentifier);
 
-        // then
-        assertThat(response.id()).isEqualTo(category.id());
-        assertThat(response.name()).isEqualTo(newName);
-        assertThat(response.color()).isEqualTo(newColor);
+            final List<CategorySequenceRequest> sequenceRequests = List.of(
+                    new CategorySequenceRequest(category1.id(), 2),
+                    new CategorySequenceRequest(category2.id(), 1)
+            );
+            final CategoryReorderRequest request = new CategoryReorderRequest(sequenceRequests);
+
+            // when
+            final CategoryReorderResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/workspaces/" + workspaceIdentifier + "/categories/reorder")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CategoryReorderResponse.class);
+
+            // then
+            assertThat(response.categorySequenceResponses()).hasSize(2);
+            assertThat(response.categorySequenceResponses()).extracting("id")
+                    .containsExactlyInAnyOrder(category1.id(), category2.id());
+        }
     }
 
-    @Test
-    @DisplayName("카테고리 삭제에 성공한다")
-    void deleteCategory_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
-        final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier);
+    @Nested
+    @DisplayName("카테고리 순서 변경 실패 시나리오")
+    class UpdateCategorySequenceFailureScenarios {
 
-        // when & then
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when()
-                .delete("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
-                .then()
-                .statusCode(HttpStatus.NO_CONTENT.value());
+        @Test
+        @DisplayName("존재하지 않는 워크스페이스의 카테고리 순서 변경 시 실패한다")
+        void updateCategorySequence_fail_workspaceNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String nonExistentIdentifier = "non-existent-identifier";
+
+            final List<CategorySequenceRequest> sequenceRequests = List.of(
+                    new CategorySequenceRequest(1L, 1)
+            );
+            final CategoryReorderRequest request = new CategoryReorderRequest(sequenceRequests);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/workspaces/" + nonExistentIdentifier + "/categories/reorder")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 워크스페이스 카테고리 순서 변경 시 실패한다")
+        void updateCategorySequence_fail_workspaceModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+            final CategoryCreateResponse category1 = createCategory(owner, workspaceIdentifier);
+
+            final String otherUser = signUpAndLogin();
+            final List<CategorySequenceRequest> sequenceRequests = List.of(
+                    new CategorySequenceRequest(category1.id(), 1)
+            );
+            final CategoryReorderRequest request = new CategoryReorderRequest(sequenceRequests);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .body(request)
+                    .when()
+                    .post("/api/workspaces/" + workspaceIdentifier + "/categories/reorder")
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN.getCode()));
+        }
     }
 
-    @Test
-    @DisplayName("카테고리 단건 조회에 성공한다")
-    void readCategory_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
-        final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier);
+    @Nested
+    @DisplayName("카테고리 수정 성공 시나리오")
+    class UpdateCategorySuccessScenarios {
 
-        // when
-        final CategoryResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when()
-                .get("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(CategoryResponse.class);
+        @Test
+        @DisplayName("카테고리 수정에 성공한다")
+        void updateCategory_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier);
 
-        // then
-        assertThat(response.id()).isEqualTo(category.id());
-        assertThat(response.name()).isEqualTo(category.name());
-        assertThat(response.color()).isEqualTo(category.color());
-        assertThat(response.sequence()).isEqualTo(category.sequence());
+            final String newName = CategoryFixture.anyName();
+            final String newColor = "#123456";
+            final CategoryUpdateRequest request = new CategoryUpdateRequest(newName, newColor);
+
+            // when
+            final CategoryUpdateResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .patch("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CategoryUpdateResponse.class);
+
+            // then
+            assertThat(response.id()).isEqualTo(category.id());
+            assertThat(response.name()).isEqualTo(newName);
+            assertThat(response.color()).isEqualTo(newColor);
+        }
     }
 
-    @Test
-    @DisplayName("카테고리 목록 조회에 성공한다")
-    void readAllCategories_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
+    @Nested
+    @DisplayName("카테고리 수정 실패 시나리오")
+    class UpdateCategoryFailureScenarios {
 
-        createCategory(accessToken, workspaceIdentifier);
-        createCategory(accessToken, workspaceIdentifier);
-        createCategory(accessToken, workspaceIdentifier);
+        @Test
+        @DisplayName("존재하지 않는 카테고리 수정 시 실패한다")
+        void updateCategory_fail_categoryNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long nonExistentCategoryId = 999999L;
 
-        // when
-        final CategoriesResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when()
-                .get("/api/workspaces/" + workspaceIdentifier + "/categories")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(CategoriesResponse.class);
+            final String newName = CategoryFixture.anyName();
+            final String newColor = "#123456";
+            final CategoryUpdateRequest request = new CategoryUpdateRequest(newName, newColor);
 
-        // then
-        assertThat(response.categoryResponses()).hasSize(3);
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .patch("/api/workspaces/" + workspaceIdentifier + "/categories/" + nonExistentCategoryId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 카테고리 수정 시 실패한다")
+        void updateCategory_fail_categoryModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+            final CategoryCreateResponse category = createCategory(owner, workspaceIdentifier);
+
+            final String otherUser = signUpAndLogin();
+            final String newName = CategoryFixture.anyName();
+            final String newColor = "#123456";
+            final CategoryUpdateRequest request = new CategoryUpdateRequest(newName, newColor);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .body(request)
+                    .when()
+                    .patch("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 워크스페이스의 카테고리 수정 시 실패한다")
+        void updateCategory_fail_categoryOutOfWorkspace() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier1 = createWorkspace(accessToken);
+            final String workspaceIdentifier2 = createWorkspace(accessToken);
+            final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier1);
+
+            final String newName = CategoryFixture.anyName();
+            final String newColor = "#123456";
+            final CategoryUpdateRequest request = new CategoryUpdateRequest(newName, newColor);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .patch("/api/workspaces/" + workspaceIdentifier2 + "/categories/" + category.id())
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_OUT_OF_WORKSPACE.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 삭제 성공 시나리오")
+    class DeleteCategorySuccessScenarios {
+
+        @Test
+        @DisplayName("카테고리 삭제에 성공한다")
+        void deleteCategory_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 삭제 실패 시나리오")
+    class DeleteCategoryFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리 삭제 시 실패한다")
+        void deleteCategory_fail_categoryNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long nonExistentCategoryId = 999999L;
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/workspaces/" + workspaceIdentifier + "/categories/" + nonExistentCategoryId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 카테고리 삭제 시 실패한다")
+        void deleteCategory_fail_categoryModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+            final CategoryCreateResponse category = createCategory(owner, workspaceIdentifier);
+
+            final String otherUser = signUpAndLogin();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .when()
+                    .delete("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 워크스페이스의 카테고리 삭제 시 실패한다")
+        void deleteCategory_fail_categoryOutOfWorkspace() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier1 = createWorkspace(accessToken);
+            final String workspaceIdentifier2 = createWorkspace(accessToken);
+            final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier1);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/workspaces/" + workspaceIdentifier2 + "/categories/" + category.id())
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_OUT_OF_WORKSPACE.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 단건 조회 성공 시나리오")
+    class ReadCategorySuccessScenarios {
+
+        @Test
+        @DisplayName("카테고리 단건 조회에 성공한다")
+        void readCategory_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier);
+
+            // when
+            final CategoryResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier + "/categories/" + category.id())
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CategoryResponse.class);
+
+            // then
+            assertThat(response.id()).isEqualTo(category.id());
+            assertThat(response.name()).isEqualTo(category.name());
+            assertThat(response.color()).isEqualTo(category.color());
+            assertThat(response.sequence()).isEqualTo(category.sequence());
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 단건 조회 실패 시나리오")
+    class ReadCategoryFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리 단건 조회 시 실패한다")
+        void readCategory_fail_categoryNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long nonExistentCategoryId = 999999L;
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier + "/categories/" + nonExistentCategoryId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 워크스페이스의 카테고리 단건 조회 시 실패한다")
+        void readCategory_fail_categoryOutOfWorkspace() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier1 = createWorkspace(accessToken);
+            final String workspaceIdentifier2 = createWorkspace(accessToken);
+            final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier1);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier2 + "/categories/" + category.id())
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_OUT_OF_WORKSPACE.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 목록 조회 성공 시나리오")
+    class ReadAllCategoriesSuccessScenarios {
+
+        @Test
+        @DisplayName("카테고리 목록 조회에 성공한다")
+        void readAllCategories_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+
+            createCategory(accessToken, workspaceIdentifier);
+            createCategory(accessToken, workspaceIdentifier);
+            createCategory(accessToken, workspaceIdentifier);
+
+            // when
+            final CategoriesResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier + "/categories")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CategoriesResponse.class);
+
+            // then
+            assertThat(response.categoryResponses()).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("카테고리가 없는 경우 빈 목록이 반환된다")
+        void readAllCategories_success_emptyList() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+
+            // when
+            final CategoriesResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier + "/categories")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CategoriesResponse.class);
+
+            // then
+            assertThat(response.categoryResponses()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 목록 조회 실패 시나리오")
+    class ReadAllCategoriesFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 워크스페이스의 카테고리 목록 조회 시 실패한다")
+        void readAllCategories_fail_workspaceNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String nonExistentIdentifier = "non-existent-identifier";
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + nonExistentIdentifier + "/categories")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 워크스페이스 카테고리 목록 조회 시 실패한다")
+        void readAllCategories_fail_workspaceModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+
+            final String otherUser = signUpAndLogin();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier + "/categories")
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN.getCode()));
+        }
     }
 
     private String signUpAndLogin() {

--- a/src/test/java/courseitda/workspace/ui/CategoryPlaceControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/CategoryPlaceControllerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import courseitda.auth.ui.dto.request.LoginRequest;
 import courseitda.auth.ui.dto.response.LoginResponse;
+import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.MemberFixture;
 import courseitda.member.ui.dto.request.SignUpRequest;
 import courseitda.place.domain.PlaceFixture;
@@ -20,6 +21,7 @@ import courseitda.workspace.ui.dto.response.WorkspaceCreateResponse;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -42,84 +44,289 @@ class CategoryPlaceControllerTest {
         RestAssured.port = port;
     }
 
-    @Test
-    @DisplayName("카테고리 장소 생성에 성공한다")
-    void createCategoryPlace_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
-        final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+    @Nested
+    @DisplayName("카테고리 장소 생성 성공 시나리오")
+    class CreateCategoryPlaceSuccessScenarios {
 
-        final String name = PlaceFixture.anyName();
-        final String roadAddressName = PlaceFixture.anyRoadAddressName();
-        final String addressName = PlaceFixture.anyAddressName();
-        final double lat = PlaceFixture.anyLatitude();
-        final double lng = PlaceFixture.anyLongitude();
+        @Test
+        @DisplayName("카테고리 장소 생성에 성공한다")
+        void createCategoryPlace_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
 
-        final CategoryPlaceCreateRequest request = new CategoryPlaceCreateRequest(
-                name, roadAddressName, addressName, lat, lng
-        );
+            final String name = PlaceFixture.anyName();
+            final String roadAddressName = PlaceFixture.anyRoadAddressName();
+            final String addressName = PlaceFixture.anyAddressName();
+            final double lat = PlaceFixture.anyLatitude();
+            final double lng = PlaceFixture.anyLongitude();
 
-        // when
-        final CategoryPlaceCreateResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(request)
-                .when()
-                .post("/api/categories/" + categoryId + "/category-places")
-                .then()
-                .statusCode(HttpStatus.CREATED.value())
-                .extract()
-                .as(CategoryPlaceCreateResponse.class);
+            final CategoryPlaceCreateRequest request = new CategoryPlaceCreateRequest(
+                    name, roadAddressName, addressName, lat, lng
+            );
 
-        // then
-        assertThat(response.id()).isNotNull();
-        assertThat(response.placeId()).isNotNull();
+            // when
+            final CategoryPlaceCreateResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/categories/" + categoryId + "/category-places")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .extract()
+                    .as(CategoryPlaceCreateResponse.class);
+
+            // then
+            assertThat(response.id()).isNotNull();
+            assertThat(response.placeId()).isNotNull();
+        }
     }
 
-    @Test
-    @DisplayName("카테고리 장소 목록 조회에 성공한다")
-    void readCategoryPlaces_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
-        final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+    @Nested
+    @DisplayName("카테고리 장소 생성 실패 시나리오")
+    class CreateCategoryPlaceFailureScenarios {
 
-        createCategoryPlace(accessToken, categoryId);
-        createCategoryPlace(accessToken, categoryId);
+        @Test
+        @DisplayName("존재하지 않는 카테고리에 장소 생성 시 실패한다")
+        void createCategoryPlace_fail_categoryNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final Long nonExistentCategoryId = 999999L;
 
-        // when
-        final CategoryPlacesResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when()
-                .get("/api/categories/" + categoryId + "/category-places")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(CategoryPlacesResponse.class);
+            final CategoryPlaceCreateRequest request = new CategoryPlaceCreateRequest(
+                    PlaceFixture.anyName(), PlaceFixture.anyRoadAddressName(),
+                    PlaceFixture.anyAddressName(), PlaceFixture.anyLatitude(), PlaceFixture.anyLongitude()
+            );
 
-        // then
-        assertThat(response.categoryPlaceResponses()).hasSize(2);
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/categories/" + nonExistentCategoryId + "/category-places")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 카테고리에 장소 생성 시 실패한다")
+        void createCategoryPlace_fail_categoryModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+            final Long categoryId = createCategory(owner, workspaceIdentifier).id();
+
+            final String otherUser = signUpAndLogin();
+            final CategoryPlaceCreateRequest request = new CategoryPlaceCreateRequest(
+                    PlaceFixture.anyName(), PlaceFixture.anyRoadAddressName(),
+                    PlaceFixture.anyAddressName(), PlaceFixture.anyLatitude(), PlaceFixture.anyLongitude()
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .body(request)
+                    .when()
+                    .post("/api/categories/" + categoryId + "/category-places")
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
     }
 
-    @Test
-    @DisplayName("카테고리 장소 삭제에 성공한다")
-    void deleteCategoryPlace_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
-        final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
-        final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId).id();
+    @Nested
+    @DisplayName("카테고리 장소 목록 조회 성공 시나리오")
+    class ReadCategoryPlacesSuccessScenarios {
 
-        // when & then
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when()
-                .delete("/api/categories/" + categoryId + "/category-places/" + categoryPlaceId)
-                .then()
-                .statusCode(HttpStatus.NO_CONTENT.value());
+        @Test
+        @DisplayName("카테고리 장소 목록 조회에 성공한다")
+        void readCategoryPlaces_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+
+            createCategoryPlace(accessToken, categoryId);
+            createCategoryPlace(accessToken, categoryId);
+
+            // when
+            final CategoryPlacesResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/categories/" + categoryId + "/category-places")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CategoryPlacesResponse.class);
+
+            // then
+            assertThat(response.categoryPlaceResponses()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("카테고리 장소가 없는 경우 빈 목록이 반환된다")
+        void readCategoryPlaces_success_emptyList() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+
+            // when
+            final CategoryPlacesResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/categories/" + categoryId + "/category-places")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CategoryPlacesResponse.class);
+
+            // then
+            assertThat(response.categoryPlaceResponses()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 장소 목록 조회 실패 시나리오")
+    class ReadCategoryPlacesFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리의 장소 목록 조회 시 실패한다")
+        void readCategoryPlaces_fail_categoryNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final Long nonExistentCategoryId = 999999L;
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/categories/" + nonExistentCategoryId + "/category-places")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 카테고리 장소 목록 조회 시 실패한다")
+        void readCategoryPlaces_fail_categoryModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+            final Long categoryId = createCategory(owner, workspaceIdentifier).id();
+
+            final String otherUser = signUpAndLogin();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .when()
+                    .get("/api/categories/" + categoryId + "/category-places")
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 장소 삭제 성공 시나리오")
+    class DeleteCategoryPlaceSuccessScenarios {
+
+        @Test
+        @DisplayName("카테고리 장소 삭제에 성공한다")
+        void deleteCategoryPlace_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId).id();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/categories/" + categoryId + "/category-places/" + categoryPlaceId)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 장소 삭제 실패 시나리오")
+    class DeleteCategoryPlaceFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리 장소 삭제 시 실패한다")
+        void deleteCategoryPlace_fail_categoryPlaceNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+            final Long nonExistentCategoryPlaceId = 999999L;
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/categories/" + categoryId + "/category-places/" + nonExistentCategoryPlaceId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_PLACE_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 카테고리 장소 삭제 시 실패한다")
+        void deleteCategoryPlace_fail_categoryModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+            final Long categoryId = createCategory(owner, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(owner, categoryId).id();
+
+            final String otherUser = signUpAndLogin();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .when()
+                    .delete("/api/categories/" + categoryId + "/category-places/" + categoryPlaceId)
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 카테고리의 장소 삭제 시 실패한다")
+        void deleteCategoryPlace_fail_placeNotBelongToCategory() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId1 = createCategory(accessToken, workspaceIdentifier).id();
+            final Long categoryId2 = createCategory(accessToken, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId1).id();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/categories/" + categoryId2 + "/category-places/" + categoryPlaceId)
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.PLACE_NOT_BELONG_TO_CATEGORY.getCode()));
+        }
     }
 
     private String signUpAndLogin() {

--- a/src/test/java/courseitda/workspace/ui/RepresentativeCategoryPlaceControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/RepresentativeCategoryPlaceControllerTest.java
@@ -181,7 +181,8 @@ class RepresentativeCategoryPlaceControllerTest {
                     .put("/api/categories/" + categoryId2 + "/representative-place")
                     .then()
                     .statusCode(HttpStatus.FORBIDDEN.value())
-                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.INVALID_REPRESENTATIVE_PLACE_ASSIGNMENT.getCode()));
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.INVALID_REPRESENTATIVE_PLACE_ASSIGNMENT
+                            .getCode()));
         }
     }
 

--- a/src/test/java/courseitda/workspace/ui/RepresentativeCategoryPlaceControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/RepresentativeCategoryPlaceControllerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import courseitda.auth.ui.dto.request.LoginRequest;
 import courseitda.auth.ui.dto.response.LoginResponse;
+import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.MemberFixture;
 import courseitda.member.ui.dto.request.SignUpRequest;
 import courseitda.place.domain.PlaceFixture;
@@ -21,6 +22,7 @@ import courseitda.workspace.ui.dto.response.WorkspaceCreateResponse;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -43,65 +45,239 @@ class RepresentativeCategoryPlaceControllerTest {
         RestAssured.port = port;
     }
 
-    @Test
-    @DisplayName("대표 카테고리 장소 업데이트에 성공한다")
-    void updateRepresentativeCategoryPlace_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
-        final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
-        final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId).id();
+    @Nested
+    @DisplayName("대표 카테고리 장소 업데이트 성공 시나리오")
+    class UpdateRepresentativeCategoryPlaceSuccessScenarios {
 
-        final RepresentativeCategoryPlaceUpdateRequest request = new RepresentativeCategoryPlaceUpdateRequest(
-                categoryPlaceId
-        );
+        @Test
+        @DisplayName("대표 카테고리 장소 업데이트에 성공한다")
+        void updateRepresentativeCategoryPlace_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId).id();
 
-        // when
-        final RepresentativeCategoryPlaceUpdateResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(request)
-                .when()
-                .put("/api/categories/" + categoryId + "/representative-place")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(RepresentativeCategoryPlaceUpdateResponse.class);
+            final RepresentativeCategoryPlaceUpdateRequest request = new RepresentativeCategoryPlaceUpdateRequest(
+                    categoryPlaceId
+            );
 
-        // then
-        assertThat(response.id()).isEqualTo(categoryPlaceId);
+            // when
+            final RepresentativeCategoryPlaceUpdateResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .put("/api/categories/" + categoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(RepresentativeCategoryPlaceUpdateResponse.class);
+
+            // then
+            assertThat(response.id()).isEqualTo(categoryPlaceId);
+        }
     }
 
-    @Test
-    @DisplayName("대표 카테고리 장소 삭제에 성공한다")
-    void deleteRepresentativeCategoryPlace_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String workspaceIdentifier = createWorkspace(accessToken);
-        final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
-        final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId).id();
+    @Nested
+    @DisplayName("대표 카테고리 장소 업데이트 실패 시나리오")
+    class UpdateRepresentativeCategoryPlaceFailureScenarios {
 
-        final RepresentativeCategoryPlaceUpdateRequest updateRequest = new RepresentativeCategoryPlaceUpdateRequest(
-                categoryPlaceId
-        );
+        @Test
+        @DisplayName("존재하지 않는 카테고리의 대표 장소 업데이트 시 실패한다")
+        void updateRepresentativeCategoryPlace_fail_categoryNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final Long nonExistentCategoryId = 999999L;
+            final Long categoryPlaceId = 1L;
 
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(updateRequest)
-                .when()
-                .put("/api/categories/" + categoryId + "/representative-place")
-                .then()
-                .statusCode(HttpStatus.OK.value());
+            final RepresentativeCategoryPlaceUpdateRequest request = new RepresentativeCategoryPlaceUpdateRequest(
+                    categoryPlaceId
+            );
 
-        // when & then
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when()
-                .delete("/api/categories/" + categoryId + "/representative-place")
-                .then()
-                .statusCode(HttpStatus.NO_CONTENT.value());
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .put("/api/categories/" + nonExistentCategoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리 장소를 대표로 지정 시 실패한다")
+        void updateRepresentativeCategoryPlace_fail_categoryPlaceNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+            final Long nonExistentCategoryPlaceId = 999999L;
+
+            final RepresentativeCategoryPlaceUpdateRequest request = new RepresentativeCategoryPlaceUpdateRequest(
+                    nonExistentCategoryPlaceId
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .put("/api/categories/" + categoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_PLACE_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 카테고리 대표 장소 업데이트 시 실패한다")
+        void updateRepresentativeCategoryPlace_fail_categoryModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+            final Long categoryId = createCategory(owner, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(owner, categoryId).id();
+
+            final String otherUser = signUpAndLogin();
+            final RepresentativeCategoryPlaceUpdateRequest request = new RepresentativeCategoryPlaceUpdateRequest(
+                    categoryPlaceId
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .body(request)
+                    .when()
+                    .put("/api/categories/" + categoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 카테고리의 장소를 대표로 지정 시 실패한다")
+        void updateRepresentativeCategoryPlace_fail_invalidRepresentativePlaceAssignment() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId1 = createCategory(accessToken, workspaceIdentifier).id();
+            final Long categoryId2 = createCategory(accessToken, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId1).id();
+
+            final RepresentativeCategoryPlaceUpdateRequest request = new RepresentativeCategoryPlaceUpdateRequest(
+                    categoryPlaceId
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .put("/api/categories/" + categoryId2 + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.INVALID_REPRESENTATIVE_PLACE_ASSIGNMENT.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("대표 카테고리 장소 삭제 성공 시나리오")
+    class DeleteRepresentativeCategoryPlaceSuccessScenarios {
+
+        @Test
+        @DisplayName("대표 카테고리 장소 삭제에 성공한다")
+        void deleteRepresentativeCategoryPlace_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId).id();
+
+            final RepresentativeCategoryPlaceUpdateRequest updateRequest = new RepresentativeCategoryPlaceUpdateRequest(
+                    categoryPlaceId
+            );
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(updateRequest)
+                    .when()
+                    .put("/api/categories/" + categoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/categories/" + categoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("대표 카테고리 장소 삭제 실패 시나리오")
+    class DeleteRepresentativeCategoryPlaceFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리의 대표 장소 삭제 시 실패한다")
+        void deleteRepresentativeCategoryPlace_fail_categoryNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final Long nonExistentCategoryId = 999999L;
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/categories/" + nonExistentCategoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 카테고리 대표 장소 삭제 시 실패한다")
+        void deleteRepresentativeCategoryPlace_fail_categoryModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+            final Long categoryId = createCategory(owner, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(owner, categoryId).id();
+
+            final RepresentativeCategoryPlaceUpdateRequest updateRequest = new RepresentativeCategoryPlaceUpdateRequest(
+                    categoryPlaceId
+            );
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, owner)
+                    .body(updateRequest)
+                    .when()
+                    .put("/api/categories/" + categoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+
+            final String otherUser = signUpAndLogin();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .when()
+                    .delete("/api/categories/" + categoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
     }
 
     private String signUpAndLogin() {

--- a/src/test/java/courseitda/workspace/ui/WorkspaceControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/WorkspaceControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 import courseitda.auth.ui.dto.request.LoginRequest;
 import courseitda.auth.ui.dto.response.LoginResponse;
+import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.MemberFixture;
 import courseitda.member.ui.dto.request.SignUpRequest;
 import courseitda.workspace.domain.WorkspaceFixture;
@@ -16,6 +17,7 @@ import courseitda.workspace.ui.dto.response.WorkspaceUpdateResponse;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -37,97 +39,214 @@ class WorkspaceControllerTest {
         RestAssured.port = port;
     }
 
-    @Test
-    @DisplayName("워크스페이스 생성에 성공한다")
-    void createWorkspace_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String title = WorkspaceFixture.anyTitle();
-        final WorkspaceCreateRequest request = new WorkspaceCreateRequest(title);
+    @Nested
+    @DisplayName("워크스페이스 생성 성공 시나리오")
+    class CreateWorkspaceSuccessScenarios {
 
-        // when
-        final WorkspaceCreateResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(request)
-                .when()
-                .post("/api/workspaces")
-                .then()
-                .statusCode(HttpStatus.CREATED.value())
-                .extract()
-                .as(WorkspaceCreateResponse.class);
+        @Test
+        @DisplayName("워크스페이스 생성에 성공한다")
+        void createWorkspace_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String title = WorkspaceFixture.anyTitle();
+            final WorkspaceCreateRequest request = new WorkspaceCreateRequest(title);
 
-        // then
-        assertThat(response.identifier()).isNotNull();
-        assertThat(response.title()).isEqualTo(title);
+            // when
+            final WorkspaceCreateResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/workspaces")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .extract()
+                    .as(WorkspaceCreateResponse.class);
+
+            // then
+            assertThat(response.identifier()).isNotNull();
+            assertThat(response.title()).isEqualTo(title);
+        }
     }
 
-    @Test
-    @DisplayName("워크스페이스 수정에 성공한다")
-    void updateWorkspace_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String originalTitle = WorkspaceFixture.anyTitle();
-        final WorkspaceCreateRequest createRequest = new WorkspaceCreateRequest(originalTitle);
+    @Nested
+    @DisplayName("워크스페이스 생성 실패 시나리오")
+    class CreateWorkspaceFailureScenarios {
 
-        final WorkspaceCreateResponse createResponse = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(createRequest)
-                .when()
-                .post("/api/workspaces")
-                .then()
-                .statusCode(HttpStatus.CREATED.value())
-                .extract()
-                .as(WorkspaceCreateResponse.class);
+        @Test
+        @DisplayName("중복된 워크스페이스 제목으로 생성 시 실패한다")
+        void createWorkspace_fail_duplicateTitle() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String title = WorkspaceFixture.anyTitle();
+            final WorkspaceCreateRequest request = new WorkspaceCreateRequest(title);
 
-        final String newTitle = WorkspaceFixture.anyTitle();
-        final WorkspaceUpdateRequest updateRequest = new WorkspaceUpdateRequest(newTitle);
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/workspaces")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value());
 
-        // when
-        final WorkspaceUpdateResponse response = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(updateRequest)
-                .when()
-                .patch("/api/workspaces/" + createResponse.identifier())
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(WorkspaceUpdateResponse.class);
-
-        // then
-        assertThat(response.identifier()).isEqualTo(createResponse.identifier());
-        assertThat(response.title()).isEqualTo(newTitle);
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/workspaces")
+                    .then()
+                    .statusCode(HttpStatus.CONFLICT.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.DUPLICATE_WORKSPACE_TITLE.getCode()));
+        }
     }
 
-    @Test
-    @DisplayName("워크스페이스 삭제에 성공한다")
-    void deleteWorkspace_success() {
-        // given
-        final String accessToken = signUpAndLogin();
-        final String title = WorkspaceFixture.anyTitle();
-        final WorkspaceCreateRequest createRequest = new WorkspaceCreateRequest(title);
+    @Nested
+    @DisplayName("워크스페이스 수정 성공 시나리오")
+    class UpdateWorkspaceSuccessScenarios {
 
-        final WorkspaceCreateResponse createResponse = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(createRequest)
-                .when()
-                .post("/api/workspaces")
-                .then()
-                .statusCode(HttpStatus.CREATED.value())
-                .extract()
-                .as(WorkspaceCreateResponse.class);
+        @Test
+        @DisplayName("워크스페이스 수정에 성공한다")
+        void updateWorkspace_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
 
-        // when & then
-        given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when()
-                .delete("/api/workspaces/" + createResponse.identifier())
-                .then()
-                .statusCode(HttpStatus.NO_CONTENT.value());
+            final String newTitle = WorkspaceFixture.anyTitle();
+            final WorkspaceUpdateRequest updateRequest = new WorkspaceUpdateRequest(newTitle);
+
+            // when
+            final WorkspaceUpdateResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(updateRequest)
+                    .when()
+                    .patch("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceUpdateResponse.class);
+
+            // then
+            assertThat(response.identifier()).isEqualTo(workspaceIdentifier);
+            assertThat(response.title()).isEqualTo(newTitle);
+        }
+    }
+
+    @Nested
+    @DisplayName("워크스페이스 수정 실패 시나리오")
+    class UpdateWorkspaceFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 워크스페이스 수정 시 실패한다")
+        void updateWorkspace_fail_workspaceNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String nonExistentIdentifier = "non-existent-identifier";
+            final String newTitle = WorkspaceFixture.anyTitle();
+            final WorkspaceUpdateRequest updateRequest = new WorkspaceUpdateRequest(newTitle);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(updateRequest)
+                    .when()
+                    .patch("/api/workspaces/" + nonExistentIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 워크스페이스 수정 시 실패한다")
+        void updateWorkspace_fail_workspaceModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+
+            final String otherUser = signUpAndLogin();
+            final String newTitle = WorkspaceFixture.anyTitle();
+            final WorkspaceUpdateRequest updateRequest = new WorkspaceUpdateRequest(newTitle);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .body(updateRequest)
+                    .when()
+                    .patch("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("워크스페이스 삭제 성공 시나리오")
+    class DeleteWorkspaceSuccessScenarios {
+
+        @Test
+        @DisplayName("워크스페이스 삭제에 성공한다")
+        void deleteWorkspace_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("워크스페이스 삭제 실패 시나리오")
+    class DeleteWorkspaceFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 워크스페이스 삭제 시 실패한다")
+        void deleteWorkspace_fail_workspaceNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String nonExistentIdentifier = "non-existent-identifier";
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/workspaces/" + nonExistentIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 워크스페이스 삭제 시 실패한다")
+        void deleteWorkspace_fail_workspaceModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+
+            final String otherUser = signUpAndLogin();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .when()
+                    .delete("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN.getCode()));
+        }
     }
 
     private String signUpAndLogin() {
@@ -156,5 +275,22 @@ class WorkspaceControllerTest {
                 .as(LoginResponse.class);
 
         return loginResponse.tokenType() + " " + loginResponse.accessToken();
+    }
+
+    private String createWorkspace(final String accessToken) {
+        final String title = WorkspaceFixture.anyTitle();
+        final WorkspaceCreateRequest request = new WorkspaceCreateRequest(title);
+
+        return given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(request)
+                .when()
+                .post("/api/workspaces")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract()
+                .as(WorkspaceCreateResponse.class)
+                .identifier();
     }
 }

--- a/src/test/java/courseitda/workspace/ui/WorkspaceControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/WorkspaceControllerTest.java
@@ -13,6 +13,7 @@ import courseitda.workspace.domain.WorkspaceFixture;
 import courseitda.workspace.ui.dto.request.WorkspaceCreateRequest;
 import courseitda.workspace.ui.dto.request.WorkspaceUpdateRequest;
 import courseitda.workspace.ui.dto.response.WorkspaceCreateResponse;
+import courseitda.workspace.ui.dto.response.WorkspaceReadResponse;
 import courseitda.workspace.ui.dto.response.WorkspaceUpdateResponse;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,6 +101,77 @@ class WorkspaceControllerTest {
                     .then()
                     .statusCode(HttpStatus.CONFLICT.value())
                     .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.DUPLICATE_WORKSPACE_TITLE.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("워크스페이스 조회 성공 시나리오")
+    class ReadWorkspaceSuccessScenarios {
+
+        @Test
+        @DisplayName("워크스페이스 조회에 성공한다")
+        void readWorkspace_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+
+            // when
+            final WorkspaceReadResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            // then
+            assertThat(response.identifier()).isEqualTo(workspaceIdentifier);
+            assertThat(response.title()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("워크스페이스 조회 실패 시나리오")
+    class ReadWorkspaceFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 워크스페이스 조회 시 실패한다")
+        void readWorkspace_fail_workspaceNotFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String nonExistentIdentifier = "non-existent-identifier";
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + nonExistentIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 워크스페이스 조회 시 실패한다")
+        void readWorkspace_fail_workspaceModifyForbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(owner);
+
+            final String otherUser = signUpAndLogin();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN.getCode()));
         }
     }
 


### PR DESCRIPTION
## Issues

- closed #63 
- closed #62 

## ✔️ Check-list

- [x] : 테스트가 모두 통과되었나요?
- [x] : Merge할 브랜치를 확인했나요?

## 🗒️ Work Description
- 워크스페이스 상세 페이지에서 워크스페이스 제목 조회 API가 필요해서 추가했습니다.
- 모든 E2E 테스트에 대해 실패하는 테스트 케이스도 작성했습니다.
- CategoryService에서 회원의 workspace 소유권 검증 로직을 제거했습니다.
  - Catergory가 Workspace에 속하는 지 검증하는 로직도 제거가 필요해보이지만 일단 놔두었습니다.
  - Category관련 API의 URL 설계도 다시 하면 좋을 것 같습니다.

## 📷 (Optional) Screenshot

## 📚 (Optional) Reference
