### PR TITLE
feat: 회원 닉네임 중복 검증 API 추가, 회원 이메일 중복 검증 API 추가

### DIFF
--- a/src/main/java/courseitda/member/application/MemberService.java
+++ b/src/main/java/courseitda/member/application/MemberService.java
@@ -6,6 +6,8 @@ import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.Member;
 import courseitda.member.domain.MemberRepository;
 import courseitda.member.ui.dto.request.SignUpRequest;
+import courseitda.member.ui.dto.response.CheckEmailDuplicateResponse;
+import courseitda.member.ui.dto.response.CheckNicknameDuplicateResponse;
 import courseitda.member.ui.dto.response.SignUpResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -50,5 +52,17 @@ public class MemberService {
         if (memberRepository.existsByNickname(nickname)) {
             throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
         }
+    }
+
+    public CheckNicknameDuplicateResponse checkNicknameDuplicate(final String nickname) {
+        final boolean isDuplicated = memberRepository.existsByNickname(nickname);
+
+        return new CheckNicknameDuplicateResponse(isDuplicated);
+    }
+
+    public CheckEmailDuplicateResponse isEmailDuplicate(final String email) {
+        final boolean isDuplicated = memberRepository.existsByEmail(email);
+
+        return new CheckEmailDuplicateResponse(isDuplicated);
     }
 }

--- a/src/main/java/courseitda/member/application/MemberService.java
+++ b/src/main/java/courseitda/member/application/MemberService.java
@@ -43,15 +43,39 @@ public class MemberService {
     }
 
     public CheckNicknameDuplicateResponse checkNicknameDuplicate(final String nickname) {
+        validateNicknameNotEmpty(nickname);
+
         final boolean isDuplicated = memberRepository.existsByNickname(nickname);
 
         return new CheckNicknameDuplicateResponse(isDuplicated);
     }
 
     public CheckEmailDuplicateResponse isEmailDuplicate(final String email) {
+        validateEmailNotEmpty(email);
+        validateEmailFormat(email);
+
         final boolean isDuplicated = memberRepository.existsByEmail(email);
 
         return new CheckEmailDuplicateResponse(isDuplicated);
+    }
+
+    private void validateNicknameNotEmpty(final String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new BusinessException(ErrorCode.MEMBER_NICKNAME_EMPTY);
+        }
+    }
+
+    private void validateEmailNotEmpty(final String email) {
+        if (email == null || email.isBlank()) {
+            throw new BusinessException(ErrorCode.MEMBER_EMAIL_EMPTY);
+        }
+    }
+
+    private void validateEmailFormat(final String email) {
+        final String emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
+        if (!email.matches(emailRegex)) {
+            throw new BusinessException(ErrorCode.INVALID_EMAIL_FORMAT);
+        }
     }
 
     private void validateDuplicateEmail(final String email) {

--- a/src/main/java/courseitda/member/application/MemberService.java
+++ b/src/main/java/courseitda/member/application/MemberService.java
@@ -42,18 +42,6 @@ public class MemberService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
-    private void validateDuplicateEmail(final String email) {
-        if (memberRepository.existsByEmail(email)) {
-            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
-        }
-    }
-
-    private void validateDuplicateNickname(final String nickname) {
-        if (memberRepository.existsByNickname(nickname)) {
-            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
-        }
-    }
-
     public CheckNicknameDuplicateResponse checkNicknameDuplicate(final String nickname) {
         final boolean isDuplicated = memberRepository.existsByNickname(nickname);
 
@@ -64,5 +52,17 @@ public class MemberService {
         final boolean isDuplicated = memberRepository.existsByEmail(email);
 
         return new CheckEmailDuplicateResponse(isDuplicated);
+    }
+
+    private void validateDuplicateEmail(final String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+
+    private void validateDuplicateNickname(final String nickname) {
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
     }
 }

--- a/src/main/java/courseitda/member/ui/MemberController.java
+++ b/src/main/java/courseitda/member/ui/MemberController.java
@@ -2,11 +2,14 @@ package courseitda.member.ui;
 
 import courseitda.member.application.MemberService;
 import courseitda.member.ui.dto.request.SignUpRequest;
+import courseitda.member.ui.dto.response.CheckEmailDuplicateResponse;
+import courseitda.member.ui.dto.response.CheckNicknameDuplicateResponse;
 import courseitda.member.ui.dto.response.SignUpResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +30,19 @@ public class MemberController {
 
         return ResponseEntity.created(URI.create("/api/members/" + signUpResponse.id()))
                 .body(signUpResponse);
+    }
+
+    @GetMapping("/check-nickname-duplicate")
+    public ResponseEntity<CheckNicknameDuplicateResponse> checkNicknameDuplicate(final String nickname) {
+        final var checkNicknameDuplicateResponse = memberService.checkNicknameDuplicate(nickname);
+
+        return ResponseEntity.ok(checkNicknameDuplicateResponse);
+    }
+
+    @GetMapping("/check-email-duplicate")
+    public ResponseEntity<CheckEmailDuplicateResponse> checkEmailDuplicate(final String email) {
+        final var checkEmailDuplicateResponse = memberService.isEmailDuplicate(email);
+
+        return ResponseEntity.ok(checkEmailDuplicateResponse);
     }
 }

--- a/src/main/java/courseitda/member/ui/dto/request/CheckEmailDuplicateRequest.java
+++ b/src/main/java/courseitda/member/ui/dto/request/CheckEmailDuplicateRequest.java
@@ -1,0 +1,6 @@
+package courseitda.member.ui.dto.request;
+
+public record CheckEmailDuplicateRequest(
+        String email
+) {
+}

--- a/src/main/java/courseitda/member/ui/dto/request/CheckNicknameDuplicateRequest.java
+++ b/src/main/java/courseitda/member/ui/dto/request/CheckNicknameDuplicateRequest.java
@@ -1,0 +1,6 @@
+package courseitda.member.ui.dto.request;
+
+public record CheckNicknameDuplicateRequest(
+        String nickname
+) {
+}

--- a/src/main/java/courseitda/member/ui/dto/response/CheckEmailDuplicateResponse.java
+++ b/src/main/java/courseitda/member/ui/dto/response/CheckEmailDuplicateResponse.java
@@ -1,0 +1,6 @@
+package courseitda.member.ui.dto.response;
+
+public record CheckEmailDuplicateResponse(
+        boolean isDuplicated
+) {
+}

--- a/src/main/java/courseitda/member/ui/dto/response/CheckNicknameDuplicateResponse.java
+++ b/src/main/java/courseitda/member/ui/dto/response/CheckNicknameDuplicateResponse.java
@@ -1,0 +1,6 @@
+package courseitda.member.ui.dto.response;
+
+public record CheckNicknameDuplicateResponse(
+        boolean isDuplicated
+) {
+}

--- a/src/test/java/courseitda/member/ui/MemberControllerTest.java
+++ b/src/test/java/courseitda/member/ui/MemberControllerTest.java
@@ -7,6 +7,8 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.MemberFixture;
 import courseitda.member.ui.dto.request.SignUpRequest;
+import courseitda.member.ui.dto.response.CheckEmailDuplicateResponse;
+import courseitda.member.ui.dto.response.CheckNicknameDuplicateResponse;
 import courseitda.member.ui.dto.response.SignUpResponse;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
@@ -127,6 +129,200 @@ class MemberControllerTest {
                     .then()
                     .statusCode(HttpStatus.CONFLICT.value())
                     .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.DUPLICATE_NICKNAME.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 중복 검증 성공 시나리오")
+    class CheckNicknameDuplicateSuccessScenarios {
+
+        @Test
+        @DisplayName("중복되지 않은 닉네임을 검증한다")
+        void checkNicknameDuplicate_success_notDuplicated() {
+            // given
+            final String nickname = MemberFixture.anyNickname();
+
+            // when
+            final CheckNicknameDuplicateResponse response = given()
+                    .queryParam("nickname", nickname)
+                    .when()
+                    .get("/api/members/check-nickname-duplicate")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CheckNicknameDuplicateResponse.class);
+
+            // then
+            assertThat(response.isDuplicated()).isFalse();
+        }
+
+        @Test
+        @DisplayName("중복된 닉네임을 검증한다")
+        void checkNicknameDuplicate_success_duplicated() {
+            // given
+            final String nickname = MemberFixture.anyNickname();
+            final String email = MemberFixture.anyEmail();
+            final String password = MemberFixture.anyPassword();
+            final SignUpRequest request = new SignUpRequest(nickname, email, password);
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .when()
+                    .post("/api/members")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value());
+
+            // when
+            final CheckNicknameDuplicateResponse response = given()
+                    .queryParam("nickname", nickname)
+                    .when()
+                    .get("/api/members/check-nickname-duplicate")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CheckNicknameDuplicateResponse.class);
+
+            // then
+            assertThat(response.isDuplicated()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 중복 검증 실패 시나리오")
+    class CheckNicknameDuplicateFailureScenarios {
+
+        @Test
+        @DisplayName("닉네임이 null인 경우 검증에 실패한다")
+        void checkNicknameDuplicate_fail_nullNickname() {
+            // when & then
+            given()
+                    .when()
+                    .get("/api/members/check-nickname-duplicate")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.MEMBER_NICKNAME_EMPTY.getCode()));
+        }
+
+        @Test
+        @DisplayName("닉네임이 빈 문자열인 경우 검증에 실패한다")
+        void checkNicknameDuplicate_fail_emptyNickname() {
+            // given
+            final String emptyNickname = "";
+
+            // when & then
+            given()
+                    .queryParam("nickname", emptyNickname)
+                    .when()
+                    .get("/api/members/check-nickname-duplicate")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.MEMBER_NICKNAME_EMPTY.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일 중복 검증 성공 시나리오")
+    class CheckEmailDuplicateSuccessScenarios {
+
+        @Test
+        @DisplayName("중복되지 않은 이메일을 검증한다")
+        void checkEmailDuplicate_success_notDuplicated() {
+            // given
+            final String email = MemberFixture.anyEmail();
+
+            // when
+            final CheckEmailDuplicateResponse response = given()
+                    .queryParam("email", email)
+                    .when()
+                    .get("/api/members/check-email-duplicate")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CheckEmailDuplicateResponse.class);
+
+            // then
+            assertThat(response.isDuplicated()).isFalse();
+        }
+
+        @Test
+        @DisplayName("중복된 이메일을 검증한다")
+        void checkEmailDuplicate_success_duplicated() {
+            // given
+            final String nickname = MemberFixture.anyNickname();
+            final String email = MemberFixture.anyEmail();
+            final String password = MemberFixture.anyPassword();
+            final SignUpRequest request = new SignUpRequest(nickname, email, password);
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .when()
+                    .post("/api/members")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value());
+
+            // when
+            final CheckEmailDuplicateResponse response = given()
+                    .queryParam("email", email)
+                    .when()
+                    .get("/api/members/check-email-duplicate")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(CheckEmailDuplicateResponse.class);
+
+            // then
+            assertThat(response.isDuplicated()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일 중복 검증 실패 시나리오")
+    class CheckEmailDuplicateFailureScenarios {
+
+        @Test
+        @DisplayName("이메일이 null인 경우 검증에 실패한다")
+        void checkEmailDuplicate_fail_nullEmail() {
+            // when & then
+            given()
+                    .when()
+                    .get("/api/members/check-email-duplicate")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.MEMBER_EMAIL_EMPTY.getCode()));
+        }
+
+        @Test
+        @DisplayName("이메일이 빈 문자열인 경우 검증에 실패한다")
+        void checkEmailDuplicate_fail_emptyEmail() {
+            // given
+            final String emptyEmail = "";
+
+            // when & then
+            given()
+                    .queryParam("email", emptyEmail)
+                    .when()
+                    .get("/api/members/check-email-duplicate")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.MEMBER_EMAIL_EMPTY.getCode()));
+        }
+
+        @Test
+        @DisplayName("이메일 형식이 잘못된 경우 검증에 실패한다")
+        void checkEmailDuplicate_fail_invalidEmailFormat() {
+            // given
+            final String invalidEmail = "invalid-email";
+
+            // when & then
+            given()
+                    .queryParam("email", invalidEmail)
+                    .when()
+                    .get("/api/members/check-email-duplicate")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.INVALID_EMAIL_FORMAT.getCode()));
         }
     }
 }


### PR DESCRIPTION
## Issues

- closed #67 

## ✔️ Check-list

- [x] : 테스트가 모두 통과되었나요?
- [x] : Merge할 브랜치를 확인했나요?

## 🗒️ Work Description
- 회원 닉네임 중복 검증 API 추가
- 회원 이메일 중복 검증 API 추가

## 📷 (Optional) Screenshot

## 📚 (Optional) Reference
