### PR TITLE
feat: 카카오 맵 검색에서 네이버 지도 검색으로 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ DDL_AUTO=create
 MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE_NAME=courseitda
 KAKAO_API_KEY=your_kakao_api_key
+NAVER_CLIENT_ID=your_naver_client_id
+NAVER_CLIENT_SECRET=your_naver_client_secret

--- a/src/main/java/courseitda/common/exception/ErrorCode.java
+++ b/src/main/java/courseitda/common/exception/ErrorCode.java
@@ -306,6 +306,24 @@ public enum ErrorCode {
             "카카오 장소 검색 API 호출 중 오류가 발생했습니다.",
             HttpStatus.BAD_GATEWAY // 502
     ),
+
+    NAVER_PLACE_SEARCH_RESPONSE_NULL(
+            "6010",
+            "네이버 장소 검색 API 응답이 null입니다.",
+            HttpStatus.BAD_GATEWAY // 502
+    ),
+
+    NAVER_PLACE_SEARCH_STATUS_CHECK_ERROR(
+            "6011",
+            "네이버 장소 검색 API 응답 상태 확인 중 오류가 발생했습니다.",
+            HttpStatus.BAD_GATEWAY // 502
+    ),
+
+    NAVER_PLACE_SEARCH_ERROR(
+            "6012",
+            "네이버 장소 검색 API 호출 중 오류가 발생했습니다.",
+            HttpStatus.BAD_GATEWAY // 502
+    ),
     ;
 
     private final String code;

--- a/src/main/java/courseitda/placesearch/application/PlaceSearchService.java
+++ b/src/main/java/courseitda/placesearch/application/PlaceSearchService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlaceSearchService {
 
-    private static final int SEARCH_SIZE = 10;
+    private static final int SEARCH_SIZE = 5;
     private final PlaceSearcher placeSearcher;
 
     public SearchedPlacesResponse search(final String query) {

--- a/src/main/java/courseitda/placesearch/infrastructure/kakao/dto/response/KakaoPlaceSearchResponse.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/kakao/dto/response/KakaoPlaceSearchResponse.java
@@ -15,7 +15,8 @@ public record KakaoPlaceSearchResponse(
             @JsonProperty("address_name") String addressName,
             @JsonProperty("road_address_name") String roadAddressName,
             @JsonProperty("y") Double latitude,
-            @JsonProperty("x") Double longitude
+            @JsonProperty("x") Double longitude,
+            @JsonProperty("place_url") String placeUrl
     ) {
 
         public SearchedPlace toSearchedPlace() {

--- a/src/main/java/courseitda/placesearch/infrastructure/naver/NaverPlaceSearchRestClient.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/naver/NaverPlaceSearchRestClient.java
@@ -1,0 +1,28 @@
+package courseitda.placesearch.infrastructure.naver;
+
+import courseitda.placesearch.infrastructure.naver.dto.request.NaverPlaceSearchRequest;
+import courseitda.placesearch.infrastructure.naver.dto.response.NaverPlaceSearchResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@RequiredArgsConstructor
+public class NaverPlaceSearchRestClient {
+
+    private final RestClient restClient;
+
+    public NaverPlaceSearchResponse search(
+            final NaverPlaceSearchRequest naverPlaceSearchRequest
+    ) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v1/search/local.json")
+                        .queryParam("query", naverPlaceSearchRequest.query())
+                        .queryParam("display", naverPlaceSearchRequest.display())
+                        .build()
+                )
+                .retrieve()
+                .body(NaverPlaceSearchResponse.class);
+    }
+}

--- a/src/main/java/courseitda/placesearch/infrastructure/naver/NaverPlaceSearcher.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/naver/NaverPlaceSearcher.java
@@ -1,0 +1,39 @@
+package courseitda.placesearch.infrastructure.naver;
+
+import courseitda.common.exception.BusinessException;
+import courseitda.common.exception.ErrorCode;
+import courseitda.placesearch.domain.PlaceSearcher;
+import courseitda.placesearch.domain.SearchedPlace;
+import courseitda.placesearch.infrastructure.naver.dto.request.NaverPlaceSearchRequest;
+import courseitda.placesearch.infrastructure.naver.dto.response.NaverPlaceSearchResponse.NaverPlaceItem;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Primary
+@Component
+@RequiredArgsConstructor
+public class NaverPlaceSearcher implements PlaceSearcher {
+
+    private final NaverPlaceSearchRestClient naverPlaceSearchRestClient;
+
+    @Override
+    public List<SearchedPlace> searchPlaces(String keyword, Integer size) {
+        final var naverPlaceSearchResponse = naverPlaceSearchRestClient.search(
+                new NaverPlaceSearchRequest(keyword, size)
+        );
+
+        if (naverPlaceSearchResponse == null) {
+            throw new BusinessException(ErrorCode.NAVER_PLACE_SEARCH_RESPONSE_NULL);
+        }
+
+        return Arrays.stream(naverPlaceSearchResponse.items()).toList()
+                .stream()
+                .map(NaverPlaceItem::toSearchedPlace)
+                .toList();
+    }
+}

--- a/src/main/java/courseitda/placesearch/infrastructure/naver/config/NaverPlaceSearchClientConfig.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/naver/config/NaverPlaceSearchClientConfig.java
@@ -1,0 +1,47 @@
+package courseitda.placesearch.infrastructure.naver.config;
+
+import courseitda.placesearch.infrastructure.naver.NaverPlaceSearchRestClient;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class NaverPlaceSearchClientConfig {
+
+    private static final String BASE_URL = "https://openapi.naver.com";
+
+    private final String naverClientId;
+    private final String naverClientSecret;
+    private final NaverPlaceSearchErrorHandler naverPlaceSearchErrorHandler;
+
+    public NaverPlaceSearchClientConfig(
+            @Value("${naver.api.client-id}") final String naverClientId,
+            @Value("${naver.api.client-secret}") final String naverClientSecret,
+            final NaverPlaceSearchErrorHandler naverPlaceSearchErrorHandler
+    ) {
+        this.naverClientId = naverClientId;
+        this.naverClientSecret = naverClientSecret;
+        this.naverPlaceSearchErrorHandler = naverPlaceSearchErrorHandler;
+    }
+
+    @Bean
+    public NaverPlaceSearchRestClient naverLocalApiClient() {
+        final SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(2));
+        requestFactory.setReadTimeout(Duration.ofSeconds(4));
+
+        final RestClient restClient = RestClient.builder()
+                .requestFactory(requestFactory)
+                .baseUrl(BASE_URL)
+                .defaultHeader("X-Naver-Client-Id", naverClientId)
+                .defaultHeader("X-Naver-Client-Secret", naverClientSecret)
+                .defaultStatusHandler(naverPlaceSearchErrorHandler)
+                .build();
+
+        return new NaverPlaceSearchRestClient(restClient);
+    }
+
+}

--- a/src/main/java/courseitda/placesearch/infrastructure/naver/config/NaverPlaceSearchErrorHandler.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/naver/config/NaverPlaceSearchErrorHandler.java
@@ -1,0 +1,47 @@
+package courseitda.placesearch.infrastructure.naver.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import courseitda.common.exception.BusinessException;
+import courseitda.common.exception.ErrorCode;
+import courseitda.placesearch.infrastructure.naver.dto.response.NaverPlaceSearchErrorResponse;
+import java.io.IOException;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResponseErrorHandler;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverPlaceSearchErrorHandler implements ResponseErrorHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean hasError(@NonNull final ClientHttpResponse response) {
+        try {
+            final var statusCode = response.getStatusCode();
+
+            return statusCode.is4xxClientError() || statusCode.is5xxServerError();
+        } catch (final IOException ioException) {
+            throw new BusinessException(ErrorCode.NAVER_PLACE_SEARCH_STATUS_CHECK_ERROR);
+        }
+    }
+
+    @Override
+    public void handleError(
+            @NonNull final URI url,
+            @NonNull final HttpMethod method,
+            final ClientHttpResponse response
+    ) throws IOException {
+        log.warn(
+                "네이버 장소 검색 API 오류 발생: {} ",
+                objectMapper.readValue(response.getBody(), NaverPlaceSearchErrorResponse.class).message()
+        );
+        throw new BusinessException(ErrorCode.NAVER_PLACE_SEARCH_ERROR);
+    }
+}

--- a/src/main/java/courseitda/placesearch/infrastructure/naver/dto/request/NaverPlaceSearchRequest.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/naver/dto/request/NaverPlaceSearchRequest.java
@@ -1,0 +1,27 @@
+package courseitda.placesearch.infrastructure.naver.dto.request;
+
+import courseitda.common.exception.BusinessException;
+import courseitda.common.exception.ErrorCode;
+
+public record NaverPlaceSearchRequest(
+        String query,
+        Integer display
+) {
+
+    public NaverPlaceSearchRequest {
+        validateQuery(query);
+        validateDisplay(display);
+    }
+
+    private void validateQuery(final String query) {
+        if (query == null || query.isBlank()) {
+            throw new BusinessException(ErrorCode.PLACE_SEARCH_KEYWORD_EMPTY);
+        }
+    }
+
+    private void validateDisplay(final Integer display) {
+        if (display == null || display < 1 || display > 15) {
+            throw new BusinessException(ErrorCode.INVALID_PLACE_SEARCH_SIZE);
+        }
+    }
+}

--- a/src/main/java/courseitda/placesearch/infrastructure/naver/dto/response/NaverPlaceSearchErrorResponse.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/naver/dto/response/NaverPlaceSearchErrorResponse.java
@@ -1,0 +1,9 @@
+package courseitda.placesearch.infrastructure.naver.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record NaverPlaceSearchErrorResponse(
+        @JsonProperty("errorMessage") String message,
+        @JsonProperty("errorCode") String code
+) {
+}

--- a/src/main/java/courseitda/placesearch/infrastructure/naver/dto/response/NaverPlaceSearchResponse.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/naver/dto/response/NaverPlaceSearchResponse.java
@@ -19,6 +19,7 @@ public record NaverPlaceSearchResponse(
             @JsonProperty("mapx") String longitude,              // 업체, 기관이 위치한 장소의 x 좌표(WGS84 좌표계 기준).
             @JsonProperty("mapy") String latitude                // 업체, 기관이 위치한 장소의 y 좌표(WGS84 좌표계 기준)
     ) {
+
         private static final double COORDINATE_SCALE = 10000000.0;
         private static final String HTML_TAG_REGEX = "<[^>]*>";
 

--- a/src/main/java/courseitda/placesearch/infrastructure/naver/dto/response/NaverPlaceSearchResponse.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/naver/dto/response/NaverPlaceSearchResponse.java
@@ -14,9 +14,6 @@ public record NaverPlaceSearchResponse(
     public record NaverPlaceItem(
             @JsonProperty("title") String name,                  // 업체, 기관의 이름
             @JsonProperty("link") String url,                    // 업체, 기관의 상세 정보 URL
-            @JsonProperty("category") String category,           // 업체, 기관의 분류 정보
-            @JsonProperty("description") String description,     // 업체, 기관에 대한 설명
-            @JsonProperty("telephone") String telephone,         // 값을 반환하지 않는 요소. 하위 호환성을 유지하기 위해 있는 요소입니다
             @JsonProperty("address") String addressName,         // 업체, 기관명의 지번 주소
             @JsonProperty("roadAddress") String roadAddressName, // 업체, 기관명의 도로명 주소
             @JsonProperty("mapx") String longitude,              // 업체, 기관이 위치한 장소의 x 좌표(WGS84 좌표계 기준).

--- a/src/main/java/courseitda/placesearch/infrastructure/naver/dto/response/NaverPlaceSearchResponse.java
+++ b/src/main/java/courseitda/placesearch/infrastructure/naver/dto/response/NaverPlaceSearchResponse.java
@@ -1,0 +1,46 @@
+package courseitda.placesearch.infrastructure.naver.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import courseitda.placesearch.domain.SearchedPlace;
+
+public record NaverPlaceSearchResponse(
+        @JsonProperty("lastBuildDate") String lastBuildDate, // 검색 결과를 생성한 시간
+        @JsonProperty("total") Integer total,                // 총 검색 결과 개수
+        @JsonProperty("start") Integer start,                // 검색 시작 위치
+        @JsonProperty("display") Integer display,            // 한 번에 표시할 검색 결과 개수
+        @JsonProperty("items") NaverPlaceItem[] items        // 개별 검색 결과
+) {
+
+    public record NaverPlaceItem(
+            @JsonProperty("title") String name,                  // 업체, 기관의 이름
+            @JsonProperty("link") String url,                    // 업체, 기관의 상세 정보 URL
+            @JsonProperty("category") String category,           // 업체, 기관의 분류 정보
+            @JsonProperty("description") String description,     // 업체, 기관에 대한 설명
+            @JsonProperty("telephone") String telephone,         // 값을 반환하지 않는 요소. 하위 호환성을 유지하기 위해 있는 요소입니다
+            @JsonProperty("address") String addressName,         // 업체, 기관명의 지번 주소
+            @JsonProperty("roadAddress") String roadAddressName, // 업체, 기관명의 도로명 주소
+            @JsonProperty("mapx") String longitude,              // 업체, 기관이 위치한 장소의 x 좌표(WGS84 좌표계 기준).
+            @JsonProperty("mapy") String latitude                // 업체, 기관이 위치한 장소의 y 좌표(WGS84 좌표계 기준)
+    ) {
+        private static final double COORDINATE_SCALE = 10000000.0;
+        private static final String HTML_TAG_REGEX = "<[^>]*>";
+
+        public SearchedPlace toSearchedPlace() {
+            // HTML 태그 제거
+            final var cleanName = name.replaceAll(HTML_TAG_REGEX, "");
+
+            // 문자열을 double로 변환 (좌표값 보정)
+            // 실제 위도/경도 좌표로 사용하려면 10000000.0으로 나눠야 정상적인 GPS 좌표(127.1234567, 37.4567890)가 됩니다
+            final var lat = Double.parseDouble(latitude) / COORDINATE_SCALE;
+            final var lng = Double.parseDouble(longitude) / COORDINATE_SCALE;
+
+            return new SearchedPlace(
+                    cleanName,
+                    addressName,
+                    roadAddressName,
+                    lat,
+                    lng
+            );
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,8 @@ security:
 kakao:
   api:
     key: ${KAKAO_API_KEY}
+
+naver:
+  api:
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}

--- a/src/test/java/courseitda/placesearch/infrastructure/naver/NaverPlaceSearcherTest.java
+++ b/src/test/java/courseitda/placesearch/infrastructure/naver/NaverPlaceSearcherTest.java
@@ -1,0 +1,38 @@
+package courseitda.placesearch.infrastructure.naver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import courseitda.placesearch.domain.SearchedPlace;
+import java.util.List;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@DisplayName("NaverPlaceSearcher 테스트")
+@Disabled("실제 API 호출 테스트가 필요할 때만 활성화")
+class NaverPlaceSearcherTest {
+
+    @Autowired
+    private NaverPlaceSearcher naverPlaceSearcher;
+
+    @Test
+    @DisplayName("네이버 API를 통해 장소를 검색하면 SearchedPlace 목록을 반환한다")
+    void searchPlaces() {
+        // given
+        final String keyword = "잠실역";
+        final Integer size = 5;
+
+        // when
+        final List<SearchedPlace> searchedPlaces = naverPlaceSearcher.searchPlaces(keyword, size);
+
+        // then
+        for (final SearchedPlace searchedPlace : searchedPlaces) {
+            System.out.println(searchedPlace);
+        }
+        assertThat(searchedPlaces).isNotEmpty();
+        assertThat(searchedPlaces.size()).isLessThanOrEqualTo(5);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,3 +32,8 @@ security:
 kakao:
   api:
     key: kakao-api-key-for-test
+
+naver:
+  api:
+    client-id: naver-client-id-for-test
+    client-secret: naver-client-secret-for-test


### PR DESCRIPTION
## Issues

- closed #83

## ✔️ Check-list

- [x] : 테스트가 모두 통과되었나요?
- [x] : Merge할 브랜치를 확인했나요?

## 🗒️ Work Description

카카오맵 검색에서 네이버 지도 검색으로 수정

## 📷 (Optional) Screenshot

## 📚 (Optional) Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * Naver 지도 장소 검색 기능 추가
  * 새로운 API 엔드포인트: `/api/places/search/naver`

* **개선사항**
  * Kakao 장소 검색 엔드포인트 경로 변경 (`/api/places/search/kakao`)
  * Naver API 오류 처리 추가

* **설정**
  * Naver API 인증 정보 추가 필요 (환경 변수: NAVER_CLIENT_ID, NAVER_CLIENT_SECRET)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->