### PR TITLE
feat: 워크스페이스의 마지막 활동 시간 동기화 이슈 수정

### DIFF
--- a/src/main/java/courseitda/common/exception/ErrorCode.java
+++ b/src/main/java/courseitda/common/exception/ErrorCode.java
@@ -95,6 +95,12 @@ public enum ErrorCode {
             HttpStatus.UNPROCESSABLE_ENTITY // 422
     ),
 
+    WORKSPACE_LAST_ACTIVITY_AT_NULL(
+            "2006",
+            "워크스페이스의 마지막 활동 시간은 null 일 수 없습니다. (내부 오류)",
+            HttpStatus.INTERNAL_SERVER_ERROR // 500
+    ),
+
     //-----------------------------------------------------------------------------------
     // 3000 Series: Category Errors
     CATEGORY_NAME_EMPTY(

--- a/src/main/java/courseitda/workspace/application/CategoryPlaceService.java
+++ b/src/main/java/courseitda/workspace/application/CategoryPlaceService.java
@@ -37,7 +37,7 @@ public class CategoryPlaceService {
 
         final var categoryPlace = CategoryPlace.createNew(category, place);
         final var savedCategoryPlace = categoryPlaceRepository.save(categoryPlace);
-        savedCategoryPlace.updateLastActivityAt();
+        savedCategoryPlace.updateWorkspaceLastActivityAt();
 
         return CategoryPlaceCreateResponse.from(savedCategoryPlace);
     }
@@ -60,7 +60,7 @@ public class CategoryPlaceService {
             category.updateRepresentativePlaceTo(null);
         }
 
-        categoryPlace.updateLastActivityAt();
+        categoryPlace.updateWorkspaceLastActivityAt();
         categoryPlaceRepository.delete(categoryPlace);
     }
 

--- a/src/main/java/courseitda/workspace/application/CategoryPlaceService.java
+++ b/src/main/java/courseitda/workspace/application/CategoryPlaceService.java
@@ -37,6 +37,7 @@ public class CategoryPlaceService {
 
         final var categoryPlace = CategoryPlace.createNew(category, place);
         final var savedCategoryPlace = categoryPlaceRepository.save(categoryPlace);
+        savedCategoryPlace.updateLastActivityAt();
 
         return CategoryPlaceCreateResponse.from(savedCategoryPlace);
     }
@@ -59,6 +60,7 @@ public class CategoryPlaceService {
             category.updateRepresentativePlaceTo(null);
         }
 
+        categoryPlace.updateLastActivityAt();
         categoryPlaceRepository.delete(categoryPlace);
     }
 

--- a/src/main/java/courseitda/workspace/application/CategoryService.java
+++ b/src/main/java/courseitda/workspace/application/CategoryService.java
@@ -47,7 +47,7 @@ public class CategoryService {
         final var nextSequence = categoryRepository.countByWorkspaceId(workspace.getId()) + 1;
         final var category = Category.createNew(workspace, request.name(), request.color(), nextSequence);
         final var savedCategory = categoryRepository.save(category);
-        savedCategory.updateLastActivityAt();
+        savedCategory.updateWorkspaceLastActivityAt();
 
         return CategoryCreateResponse.from(savedCategory);
     }
@@ -62,7 +62,7 @@ public class CategoryService {
         category.validateOwnership(memberAuthInfo.id());
 
         category.updateNameAndColor(request.name(), request.color());
-        category.updateLastActivityAt();
+        category.updateWorkspaceLastActivityAt();
 
         return CategoryUpdateResponse.from(category);
     }
@@ -79,7 +79,7 @@ public class CategoryService {
         final var candidatePlace = getCategoryPlaceById(request.categoryPlaceId());
 
         category.updateRepresentativePlaceTo(candidatePlace);
-        category.updateLastActivityAt();
+        category.updateWorkspaceLastActivityAt();
 
         return RepresentativeCategoryPlaceUpdateResponse.from(category.getRepresentativePlace());
     }
@@ -128,7 +128,7 @@ public class CategoryService {
         category.validateOwnership(memberAuthInfo.id());
 
         category.updateRepresentativePlaceTo(null);
-        category.updateLastActivityAt();
+        category.updateWorkspaceLastActivityAt();
     }
 
     @Transactional
@@ -136,7 +136,7 @@ public class CategoryService {
         final var category = getCategoryById(categoryId);
         category.validateOwnership(memberAuthInfo.id());
 
-        category.updateLastActivityAt();
+        category.updateWorkspaceLastActivityAt();
         categoryRepository.delete(category);
     }
 
@@ -150,7 +150,7 @@ public class CategoryService {
 
     @Transactional(readOnly = true)
     public CategoriesReadResponse findAllCategories(final MemberAuthInfo memberAuthInfo,
-            final String workspaceIdentifier) {
+                                                    final String workspaceIdentifier) {
         final var workspace = getWorkspaceByIdentifier(workspaceIdentifier);
         workspace.validateOwnership(memberAuthInfo.id());
         final var categories = workspace.getCategories();

--- a/src/main/java/courseitda/workspace/application/CategoryService.java
+++ b/src/main/java/courseitda/workspace/application/CategoryService.java
@@ -149,8 +149,10 @@ public class CategoryService {
     }
 
     @Transactional(readOnly = true)
-    public CategoriesReadResponse findAllCategories(final MemberAuthInfo memberAuthInfo,
-                                                    final String workspaceIdentifier) {
+    public CategoriesReadResponse findAllCategories(
+            final MemberAuthInfo memberAuthInfo,
+            final String workspaceIdentifier
+    ) {
         final var workspace = getWorkspaceByIdentifier(workspaceIdentifier);
         workspace.validateOwnership(memberAuthInfo.id());
         final var categories = workspace.getCategories();

--- a/src/main/java/courseitda/workspace/application/CategoryService.java
+++ b/src/main/java/courseitda/workspace/application/CategoryService.java
@@ -150,7 +150,7 @@ public class CategoryService {
 
     @Transactional(readOnly = true)
     public CategoriesReadResponse findAllCategories(final MemberAuthInfo memberAuthInfo,
-                                                    final String workspaceIdentifier) {
+            final String workspaceIdentifier) {
         final var workspace = getWorkspaceByIdentifier(workspaceIdentifier);
         workspace.validateOwnership(memberAuthInfo.id());
         final var categories = workspace.getCategories();

--- a/src/main/java/courseitda/workspace/application/CategoryService.java
+++ b/src/main/java/courseitda/workspace/application/CategoryService.java
@@ -47,6 +47,7 @@ public class CategoryService {
         final var nextSequence = categoryRepository.countByWorkspaceId(workspace.getId()) + 1;
         final var category = Category.createNew(workspace, request.name(), request.color(), nextSequence);
         final var savedCategory = categoryRepository.save(category);
+        savedCategory.updateLastActivityAt();
 
         return CategoryCreateResponse.from(savedCategory);
     }
@@ -61,6 +62,7 @@ public class CategoryService {
         category.validateOwnership(memberAuthInfo.id());
 
         category.updateNameAndColor(request.name(), request.color());
+        category.updateLastActivityAt();
 
         return CategoryUpdateResponse.from(category);
     }
@@ -77,6 +79,7 @@ public class CategoryService {
         final var candidatePlace = getCategoryPlaceById(request.categoryPlaceId());
 
         category.updateRepresentativePlaceTo(candidatePlace);
+        category.updateLastActivityAt();
 
         return RepresentativeCategoryPlaceUpdateResponse.from(category.getRepresentativePlace());
     }
@@ -114,6 +117,7 @@ public class CategoryService {
             validateCategoryBelongsToWorkspace(workspace, category);
             category.updateSequence(sequenceCommand.sequence());
         }
+        workspace.updateLastActivityAt();
 
         return CategorySequenceUpdateResponse.from(categories);
     }
@@ -124,6 +128,7 @@ public class CategoryService {
         category.validateOwnership(memberAuthInfo.id());
 
         category.updateRepresentativePlaceTo(null);
+        category.updateLastActivityAt();
     }
 
     @Transactional
@@ -131,6 +136,7 @@ public class CategoryService {
         final var category = getCategoryById(categoryId);
         category.validateOwnership(memberAuthInfo.id());
 
+        category.updateLastActivityAt();
         categoryRepository.delete(category);
     }
 
@@ -144,7 +150,7 @@ public class CategoryService {
 
     @Transactional(readOnly = true)
     public CategoriesReadResponse findAllCategories(final MemberAuthInfo memberAuthInfo,
-            final String workspaceIdentifier) {
+                                                    final String workspaceIdentifier) {
         final var workspace = getWorkspaceByIdentifier(workspaceIdentifier);
         workspace.validateOwnership(memberAuthInfo.id());
         final var categories = workspace.getCategories();

--- a/src/main/java/courseitda/workspace/application/WorkspaceService.java
+++ b/src/main/java/courseitda/workspace/application/WorkspaceService.java
@@ -47,6 +47,7 @@ public class WorkspaceService {
             validateDuplicatedTitle(memberAuthInfo.id(), newTitle);
         }
         workspace.rename(newTitle);
+        workspace.updateLastActivityAt();
 
         return WorkspaceUpdateResponse.from(workspace);
     }

--- a/src/main/java/courseitda/workspace/domain/Category.java
+++ b/src/main/java/courseitda/workspace/domain/Category.java
@@ -107,6 +107,10 @@ public class Category extends Timestamp {
         this.color = newColor;
     }
 
+    public void updateLastActivityAt() {
+        workspace.updateLastActivityAt();
+    }
+
     public void validateOwnership(final Long memberId) {
         if (!workspace.isOwnedBy(memberId)) {
             throw new BusinessException(ErrorCode.CATEGORY_MODIFY_FORBIDDEN);

--- a/src/main/java/courseitda/workspace/domain/Category.java
+++ b/src/main/java/courseitda/workspace/domain/Category.java
@@ -107,7 +107,7 @@ public class Category extends Timestamp {
         this.color = newColor;
     }
 
-    public void updateLastActivityAt() {
+    public void updateWorkspaceLastActivityAt() {
         workspace.updateLastActivityAt();
     }
 

--- a/src/main/java/courseitda/workspace/domain/CategoryPlace.java
+++ b/src/main/java/courseitda/workspace/domain/CategoryPlace.java
@@ -46,8 +46,8 @@ public class CategoryPlace extends Timestamp {
         return new CategoryPlace(null, category, place);
     }
 
-    public void updateLastActivityAt() {
-        category.updateLastActivityAt();
+    public void updateWorkspaceLastActivityAt() {
+        category.updateWorkspaceLastActivityAt();
     }
 
     public void validateOwnership(final Long memberId) {

--- a/src/main/java/courseitda/workspace/domain/CategoryPlace.java
+++ b/src/main/java/courseitda/workspace/domain/CategoryPlace.java
@@ -46,6 +46,10 @@ public class CategoryPlace extends Timestamp {
         return new CategoryPlace(null, category, place);
     }
 
+    public void updateLastActivityAt() {
+        category.updateLastActivityAt();
+    }
+
     public void validateOwnership(final Long memberId) {
         this.category.validateOwnership(memberId);
     }

--- a/src/main/java/courseitda/workspace/domain/Workspace.java
+++ b/src/main/java/courseitda/workspace/domain/Workspace.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -44,6 +45,9 @@ public class Workspace extends Timestamp {
     @Column(nullable = false)
     private String title;
 
+    @Column(nullable = false)
+    private LocalDateTime lastActivityAt;
+
     @OneToMany(mappedBy = "workspace")
     private List<Category> categories;
 
@@ -52,18 +56,21 @@ public class Workspace extends Timestamp {
             final Member owner,
             final String identifier,
             final String title,
+            final LocalDateTime lastActivityAt,
             final List<Category> categories
     ) {
         validateTitle(title);
+        validateLastActivityAt(lastActivityAt);
 
         this.owner = owner;
         this.identifier = identifier;
         this.title = title;
+        this.lastActivityAt = lastActivityAt;
         this.categories = categories;
     }
 
     public static Workspace createNew(final Member owner, final String title) {
-        return new Workspace(owner, UUID.randomUUID().toString(), title, new ArrayList<>());
+        return new Workspace(owner, UUID.randomUUID().toString(), title, LocalDateTime.now(), new ArrayList<>());
     }
 
     public static String formatTitle(final String unformattedTitle) {
@@ -79,6 +86,10 @@ public class Workspace extends Timestamp {
         this.title = newTitle;
     }
 
+    public void updateLastActivityAt() {
+        this.lastActivityAt = LocalDateTime.now();
+    }
+
     public void validateOwnership(final Long memberId) {
         if (!isOwnedBy(memberId)) {
             throw new BusinessException(ErrorCode.WORKSPACE_MODIFY_FORBIDDEN);
@@ -91,6 +102,12 @@ public class Workspace extends Timestamp {
         }
         if (title.length() > 20) {
             throw new BusinessException(ErrorCode.WORKSPACE_TITLE_LENGTH_EXCEEDED);
+        }
+    }
+
+    private void validateLastActivityAt(final LocalDateTime lastActivityAt) {
+        if (lastActivityAt == null) {
+            throw new BusinessException(ErrorCode.WORKSPACE_LAST_ACTIVITY_AT_NULL);
         }
     }
 }

--- a/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceCreateResponse.java
+++ b/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceCreateResponse.java
@@ -1,20 +1,21 @@
 package courseitda.workspace.ui.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import courseitda.workspace.domain.Workspace;
 import java.time.LocalDateTime;
 
 public record WorkspaceCreateResponse(
         String identifier,
         String title,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime modifiedAt
+        @JsonProperty("modifiedAt") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime lastActivityAt
 ) {
 
     public static WorkspaceCreateResponse from(final Workspace workspace) {
         return new WorkspaceCreateResponse(
                 workspace.getIdentifier(),
                 workspace.getTitle(),
-                workspace.getModifiedAt()
+                workspace.getLastActivityAt()
         );
     }
 }

--- a/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceReadResponse.java
+++ b/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceReadResponse.java
@@ -1,20 +1,21 @@
 package courseitda.workspace.ui.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import courseitda.workspace.domain.Workspace;
 import java.time.LocalDateTime;
 
 public record WorkspaceReadResponse(
         String identifier,
         String title,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime modifiedAt
+        @JsonProperty("modifiedAt") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime lastActivityAt
 ) {
 
     public static WorkspaceReadResponse from(final Workspace workspace) {
         return new WorkspaceReadResponse(
                 workspace.getIdentifier(),
                 workspace.getTitle(),
-                workspace.getModifiedAt()
+                workspace.getLastActivityAt()
         );
     }
 }

--- a/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceUpdateResponse.java
+++ b/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceUpdateResponse.java
@@ -1,20 +1,21 @@
 package courseitda.workspace.ui.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import courseitda.workspace.domain.Workspace;
 import java.time.LocalDateTime;
 
 public record WorkspaceUpdateResponse(
         String identifier,
         String title,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime modifiedAt
+        @JsonProperty("modifiedAt") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime lastActivityAt
 ) {
 
     public static WorkspaceUpdateResponse from(final Workspace workspace) {
         return new WorkspaceUpdateResponse(
                 workspace.getIdentifier(),
                 workspace.getTitle(),
-                workspace.getModifiedAt()
+                workspace.getLastActivityAt()
         );
     }
 }

--- a/src/test/java/courseitda/workspace/ui/CategoryControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/CategoryControllerTest.java
@@ -23,6 +23,7 @@ import courseitda.workspace.ui.dto.response.CategoryReadResponse;
 import courseitda.workspace.ui.dto.response.CategoryUpdateResponse;
 import courseitda.workspace.ui.dto.response.RepresentativeCategoryPlaceUpdateResponse;
 import courseitda.workspace.ui.dto.response.WorkspaceCreateResponse;
+import courseitda.workspace.ui.dto.response.WorkspaceReadResponse;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -578,6 +579,216 @@ class CategoryControllerTest {
                     .then()
                     .statusCode(HttpStatus.FORBIDDEN.value())
                     .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 작업 시 워크스페이스 마지막 활동 시간 업데이트 시나리오")
+    class CategoryWorkspaceLastActivityAtUpdateScenarios {
+
+        @Test
+        @DisplayName("카테고리 수정 시 워크스페이스 lastActivityAt이 업데이트된다")
+        void updateCategory_updatesWorkspaceLastActivityAt() throws InterruptedException {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier);
+
+            Thread.sleep(1000);
+
+            final WorkspaceReadResponse beforeUpdate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            Thread.sleep(1000);
+
+            final String newName = CategoryFixture.anyName();
+            final String newColor = "#123456";
+            final CategoryUpdateRequest request = new CategoryUpdateRequest(newName, newColor);
+
+            // when
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .patch("/api/categories/" + category.id())
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+
+            final WorkspaceReadResponse afterUpdate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            // then
+            assertThat(afterUpdate.lastActivityAt()).isAfter(beforeUpdate.lastActivityAt());
+        }
+
+        @Test
+        @DisplayName("카테고리 삭제 시 워크스페이스 lastActivityAt이 업데이트된다")
+        void deleteCategory_updatesWorkspaceLastActivityAt() throws InterruptedException {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final CategoryCreateResponse category = createCategory(accessToken, workspaceIdentifier);
+
+            Thread.sleep(1000);
+
+            final WorkspaceReadResponse beforeDelete = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            Thread.sleep(1000);
+
+            // when
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/categories/" + category.id())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            final WorkspaceReadResponse afterDelete = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            // then
+            assertThat(afterDelete.lastActivityAt()).isAfter(beforeDelete.lastActivityAt());
+        }
+
+        @Test
+        @DisplayName("대표 카테고리 장소 업데이트 시 워크스페이스 lastActivityAt이 업데이트된다")
+        void updateRepresentativeCategoryPlace_updatesWorkspaceLastActivityAt() throws InterruptedException {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId).id();
+
+            Thread.sleep(1000);
+
+            final WorkspaceReadResponse beforeUpdate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            Thread.sleep(1000);
+
+            final RepresentativeCategoryPlaceUpdateRequest request = new RepresentativeCategoryPlaceUpdateRequest(
+                    categoryPlaceId
+            );
+
+            // when
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .put("/api/categories/" + categoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+
+            final WorkspaceReadResponse afterUpdate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            // then
+            assertThat(afterUpdate.lastActivityAt()).isAfter(beforeUpdate.lastActivityAt());
+        }
+
+        @Test
+        @DisplayName("대표 카테고리 장소 삭제 시 워크스페이스 lastActivityAt이 업데이트된다")
+        void deleteRepresentativeCategoryPlace_updatesWorkspaceLastActivityAt() throws InterruptedException {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId).id();
+
+            final RepresentativeCategoryPlaceUpdateRequest updateRequest = new RepresentativeCategoryPlaceUpdateRequest(
+                    categoryPlaceId
+            );
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(updateRequest)
+                    .when()
+                    .put("/api/categories/" + categoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+
+            Thread.sleep(1000);
+
+            final WorkspaceReadResponse beforeDelete = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            Thread.sleep(1000);
+
+            // when
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/categories/" + categoryId + "/representative-place")
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            final WorkspaceReadResponse afterDelete = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            // then
+            assertThat(afterDelete.lastActivityAt()).isAfter(beforeDelete.lastActivityAt());
         }
     }
 

--- a/src/test/java/courseitda/workspace/ui/CategoryPlaceControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/CategoryPlaceControllerTest.java
@@ -18,6 +18,7 @@ import courseitda.workspace.ui.dto.response.CategoryCreateResponse;
 import courseitda.workspace.ui.dto.response.CategoryPlaceCreateResponse;
 import courseitda.workspace.ui.dto.response.CategoryPlacesFindResponse;
 import courseitda.workspace.ui.dto.response.WorkspaceCreateResponse;
+import courseitda.workspace.ui.dto.response.WorkspaceReadResponse;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -411,6 +412,96 @@ class CategoryPlaceControllerTest {
                     .then()
                     .statusCode(HttpStatus.FORBIDDEN.value())
                     .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.PLACE_NOT_BELONG_TO_CATEGORY.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 장소 작업 시 워크스페이스 마지막 활동 시간 업데이트 시나리오")
+    class CategoryPlaceWorkspaceLastActivityAtUpdateScenarios {
+
+        @Test
+        @DisplayName("카테고리 장소 생성 시 워크스페이스 lastActivityAt이 업데이트된다")
+        void createCategoryPlace_updatesWorkspaceLastActivityAt() throws InterruptedException {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+
+            Thread.sleep(1000);
+
+            final WorkspaceReadResponse beforeCreate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            Thread.sleep(1000);
+
+            // when
+            createCategoryPlace(accessToken, categoryId);
+
+            final WorkspaceReadResponse afterCreate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            // then
+            assertThat(afterCreate.lastActivityAt()).isAfter(beforeCreate.lastActivityAt());
+        }
+
+        @Test
+        @DisplayName("카테고리 장소 삭제 시 워크스페이스 lastActivityAt이 업데이트된다")
+        void deleteCategoryPlace_updatesWorkspaceLastActivityAt() throws InterruptedException {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final Long categoryId = createCategory(accessToken, workspaceIdentifier).id();
+            final Long categoryPlaceId = createCategoryPlace(accessToken, categoryId).id();
+
+            Thread.sleep(1000);
+
+            final WorkspaceReadResponse beforeDelete = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            Thread.sleep(1000);
+
+            // when
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/categories/" + categoryId + "/places/" + categoryPlaceId)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            final WorkspaceReadResponse afterDelete = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            // then
+            assertThat(afterDelete.lastActivityAt()).isAfter(beforeDelete.lastActivityAt());
         }
     }
 }

--- a/src/test/java/courseitda/workspace/ui/WorkspaceControllerTest.java
+++ b/src/test/java/courseitda/workspace/ui/WorkspaceControllerTest.java
@@ -805,4 +805,136 @@ class WorkspaceControllerTest {
                     .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.WORKSPACE_TITLE_EMPTY.getCode()));
         }
     }
+
+    @Nested
+    @DisplayName("워크스페이스 마지막 활동 시간 업데이트 시나리오")
+    class WorkspaceLastActivityAtUpdateScenarios {
+
+        @Test
+        @DisplayName("워크스페이스 수정 시 lastActivityAt이 업데이트된다")
+        void updateWorkspace_updatesLastActivityAt() throws InterruptedException {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+
+            final WorkspaceReadResponse beforeUpdate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            Thread.sleep(1000);
+
+            final String newTitle = WorkspaceFixture.anyTitle();
+            final WorkspaceUpdateRequest updateRequest = new WorkspaceUpdateRequest(newTitle);
+
+            // when
+            final WorkspaceUpdateResponse updateResponse = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(updateRequest)
+                    .when()
+                    .patch("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceUpdateResponse.class);
+
+            // then
+            assertThat(updateResponse.lastActivityAt()).isAfter(beforeUpdate.lastActivityAt());
+        }
+
+        @Test
+        @DisplayName("카테고리 생성 시 워크스페이스 lastActivityAt이 업데이트된다")
+        void createCategory_updatesWorkspaceLastActivityAt() throws InterruptedException {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+
+            final WorkspaceReadResponse beforeCreate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            Thread.sleep(1000);
+
+            // when
+            createCategory(accessToken, workspaceIdentifier);
+
+            final WorkspaceReadResponse afterCreate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            // then
+            assertThat(afterCreate.lastActivityAt()).isAfter(beforeCreate.lastActivityAt());
+        }
+
+        @Test
+        @DisplayName("카테고리 순서 변경 시 워크스페이스 lastActivityAt이 업데이트된다")
+        void updateCategorySequence_updatesWorkspaceLastActivityAt() throws InterruptedException {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String workspaceIdentifier = createWorkspace(accessToken);
+            final CategoryCreateResponse category1 = createCategory(accessToken, workspaceIdentifier);
+            final CategoryCreateResponse category2 = createCategory(accessToken, workspaceIdentifier);
+
+            Thread.sleep(1000);
+
+            final WorkspaceReadResponse beforeUpdate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            Thread.sleep(1000);
+
+            final List<CategorySequenceRequest> sequenceRequests = List.of(
+                    new CategorySequenceRequest(category1.id(), 2),
+                    new CategorySequenceRequest(category2.id(), 1)
+            );
+            final CategoryReorderRequest request = new CategoryReorderRequest(sequenceRequests);
+
+            // when
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/workspaces/" + workspaceIdentifier + "/categories/sequence")
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+
+            final WorkspaceReadResponse afterUpdate = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/workspaces/" + workspaceIdentifier)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(WorkspaceReadResponse.class);
+
+            // then
+            assertThat(afterUpdate.lastActivityAt()).isAfter(beforeUpdate.lastActivityAt());
+        }
+    }
 }


### PR DESCRIPTION
## Issues

- closed #98

## ✔️ Check-list

- [x] : 테스트가 모두 통과되었나요?
- [x] : Merge할 브랜치를 확인했나요?

## 🗒️ Work Description

- 워크스페이스의 마지막 활동 시간 동기화 이슈 해결
- notion > backend 에 [해결과정](https://www.notion.so/Workspace-2ab64056d2d28042adc9c797712e48b5?source=copy_link) 작성

## 📷 (Optional) Screenshot

## 📚 (Optional) Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크스페이스 마지막 활동 시간 추적: 각 워크스페이스의 마지막 활동 시간을 자동으로 기록하고 API 응답에 포함합니다
  * 카테고리 생성·수정·삭제, 장소 생성·삭제, 워크스페이스 제목 변경 등의 작업 수행 시 마지막 활동 시간을 자동으로 업데이트합니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->