### PR TITLE
refactor: 프로그램 전체 시간 형식 수정

### DIFF
--- a/src/main/java/courseitda/CourseitdaApplication.java
+++ b/src/main/java/courseitda/CourseitdaApplication.java
@@ -2,9 +2,7 @@ package courseitda;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class CourseitdaApplication {
 

--- a/src/main/java/courseitda/common/entity/Timestamp.java
+++ b/src/main/java/courseitda/common/entity/Timestamp.java
@@ -1,23 +1,37 @@
 package courseitda.common.entity;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+/**
+ * 엔티티의 생성/수정 시간을 KST 기준으로 자동 관리하는 기본 클래스. 주의: @PrePersist/@PreUpdate는 JPA 라이프사이클 콜백이므로, Native SQL이나 @Modifying 벌크 연산
+ * 사용 시에는 동작하지 않습니다. 이 경우 쿼리에서 직접 타임스탬프를 설정해야 합니다.
+ */
 @Getter
 @MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
 public abstract class Timestamp {
 
-    @CreatedDate
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
     @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
     private LocalDateTime modifiedAt;
+
+    @PrePersist
+    private void prePersist() {
+        final LocalDateTime now = LocalDateTime.now(KST);
+        this.createdAt = now;
+        this.modifiedAt = now;
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        this.modifiedAt = LocalDateTime.now(KST);
+    }
 }

--- a/src/main/java/courseitda/common/entity/Timestamp.java
+++ b/src/main/java/courseitda/common/entity/Timestamp.java
@@ -1,5 +1,6 @@
 package courseitda.common.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
@@ -19,8 +20,10 @@ public abstract class Timestamp {
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     @Column(updatable = false, nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss+09:00")
     private LocalDateTime createdAt;
 
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss+09:00")
     private LocalDateTime modifiedAt;
 
     @PrePersist

--- a/src/main/java/courseitda/member/ui/dto/response/MyWorkspacesResponse.java
+++ b/src/main/java/courseitda/member/ui/dto/response/MyWorkspacesResponse.java
@@ -1,6 +1,7 @@
 package courseitda.member.ui.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import courseitda.workspace.domain.Workspace;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,14 +21,14 @@ public record MyWorkspacesResponse(
     public record WorkspaceResponse(
             String identifier,
             String title,
-            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime modifiedAt
+            @JsonProperty("modifiedAt") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss+09:00") LocalDateTime lastActivityAt
     ) {
 
         public static WorkspaceResponse from(final Workspace workspace) {
             return new WorkspaceResponse(
                     workspace.getIdentifier(),
                     workspace.getTitle(),
-                    workspace.getModifiedAt()
+                    workspace.getLastActivityAt()
             );
         }
     }

--- a/src/main/java/courseitda/workspace/domain/Workspace.java
+++ b/src/main/java/courseitda/workspace/domain/Workspace.java
@@ -1,5 +1,6 @@
 package courseitda.workspace.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import courseitda.common.entity.Timestamp;
 import courseitda.common.exception.BusinessException;
 import courseitda.common.exception.ErrorCode;
@@ -14,6 +15,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -31,6 +33,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public class Workspace extends Timestamp {
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -46,6 +50,7 @@ public class Workspace extends Timestamp {
     private String title;
 
     @Column(nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss+09:00")
     private LocalDateTime lastActivityAt;
 
     @OneToMany(mappedBy = "workspace")
@@ -70,7 +75,7 @@ public class Workspace extends Timestamp {
     }
 
     public static Workspace createNew(final Member owner, final String title) {
-        return new Workspace(owner, UUID.randomUUID().toString(), title, LocalDateTime.now(), new ArrayList<>());
+        return new Workspace(owner, UUID.randomUUID().toString(), title, LocalDateTime.now(KST), new ArrayList<>());
     }
 
     public static String formatTitle(final String unformattedTitle) {
@@ -87,7 +92,7 @@ public class Workspace extends Timestamp {
     }
 
     public void updateLastActivityAt() {
-        this.lastActivityAt = LocalDateTime.now();
+        this.lastActivityAt = LocalDateTime.now(KST);
     }
 
     public void validateOwnership(final Long memberId) {

--- a/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceCreateResponse.java
+++ b/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceCreateResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 public record WorkspaceCreateResponse(
         String identifier,
         String title,
-        @JsonProperty("modifiedAt") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime lastActivityAt
+        @JsonProperty("modifiedAt") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss+09:00") LocalDateTime lastActivityAt
 ) {
 
     public static WorkspaceCreateResponse from(final Workspace workspace) {

--- a/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceReadResponse.java
+++ b/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceReadResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 public record WorkspaceReadResponse(
         String identifier,
         String title,
-        @JsonProperty("modifiedAt") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime lastActivityAt
+        @JsonProperty("modifiedAt") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss+09:00") LocalDateTime lastActivityAt
 ) {
 
     public static WorkspaceReadResponse from(final Workspace workspace) {

--- a/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceUpdateResponse.java
+++ b/src/main/java/courseitda/workspace/ui/dto/response/WorkspaceUpdateResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 public record WorkspaceUpdateResponse(
         String identifier,
         String title,
-        @JsonProperty("modifiedAt") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime lastActivityAt
+        @JsonProperty("modifiedAt") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss+09:00") LocalDateTime lastActivityAt
 ) {
 
     public static WorkspaceUpdateResponse from(final Workspace workspace) {

--- a/src/main/resources/logback-dev.xml
+++ b/src/main/resources/logback-dev.xml
@@ -20,8 +20,8 @@
         <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
             <providers>
                 <timestamp>
-                    <timeZone>UTC</timeZone>
-                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSX</pattern>
+                    <timeZone>Asia/Seoul</timeZone>
+                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</pattern>
                     <fieldName>timestamp</fieldName>
                 </timestamp>
                 <logLevel>
@@ -55,8 +55,8 @@
         <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
             <providers>
                 <timestamp>
-                    <timeZone>UTC</timeZone>
-                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSX</pattern>
+                    <timeZone>Asia/Seoul</timeZone>
+                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</pattern>
                     <fieldName>timestamp</fieldName>
                 </timestamp>
                 <logLevel>
@@ -90,8 +90,8 @@
         <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
             <providers>
                 <timestamp>
-                    <timeZone>UTC</timeZone>
-                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSX</pattern>
+                    <timeZone>Asia/Seoul</timeZone>
+                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</pattern>
                     <fieldName>timestamp</fieldName>
                 </timestamp>
                 <logLevel>
@@ -134,8 +134,8 @@
 
         <!-- JSON 형식으로 출력: 시스템 로그는 기본 필드 포함 -->
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <timeZone>UTC</timeZone>
-            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampPattern>
+            <timeZone>Asia/Seoul</timeZone>
+            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</timestampPattern>
             <fieldNames>
                 <timestamp>timestamp</timestamp>
                 <logger>logger_name</logger>

--- a/src/main/resources/logback-local.xml
+++ b/src/main/resources/logback-local.xml
@@ -20,8 +20,8 @@
             <providers>
                 <!-- 타임스탬프 -->
                 <timestamp>
-                    <timeZone>UTC</timeZone>
-                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSX</pattern>
+                    <timeZone>Asia/Seoul</timeZone>
+                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</pattern>
                     <fieldName>timestamp</fieldName>
                 </timestamp>
                 <!-- 로그 레벨 -->
@@ -60,8 +60,8 @@
             <providers>
                 <!-- 타임스탬프 -->
                 <timestamp>
-                    <timeZone>UTC</timeZone>
-                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSX</pattern>
+                    <timeZone>Asia/Seoul</timeZone>
+                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</pattern>
                     <fieldName>timestamp</fieldName>
                 </timestamp>
                 <!-- 로그 레벨 -->
@@ -100,8 +100,8 @@
             <providers>
                 <!-- 타임스탬프 -->
                 <timestamp>
-                    <timeZone>UTC</timeZone>
-                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSX</pattern>
+                    <timeZone>Asia/Seoul</timeZone>
+                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</pattern>
                     <fieldName>timestamp</fieldName>
                 </timestamp>
                 <!-- 로그 레벨 -->
@@ -147,8 +147,8 @@
 
         <!-- JSON 형식으로 출력: 시스템 로그는 기본 필드 포함 -->
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <timeZone>UTC</timeZone>
-            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampPattern>
+            <timeZone>Asia/Seoul</timeZone>
+            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</timestampPattern>
             <fieldNames>
                 <timestamp>timestamp</timestamp>
                 <logger>logger_name</logger>


### PR DESCRIPTION
## Issues

- closed #101

## ✔️ Check-list

- [x] : 테스트가 모두 통과되었나요?
- [x] : Merge할 브랜치를 확인했나요?

## 🗒️ Work Description

Timestamp, Logback 등 시간이 사용되는 파일에서 시간 형식을 KST기준으로 일괄 조정

## 📷 (Optional) Screenshot

## 📚 (Optional) Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 타임스탬프 관리를 JPA 라이프사이클 콜백으로 전환하고 모든 시간 표기를 KST(Asia/Seoul)로 통일했습니다.
  * 날짜 직렬화 포맷에 시간대 오프셋(+09:00)을 추가했습니다.
  * 로그 설정의 timezone과 타임스탬프 패턴을 Asia/Seoul로 변경했습니다.

* **Breaking Changes**
  * 일부 응답 DTO에서 내부 필드명이 modifiedAt → lastActivityAt로 변경되었고, JSON 노출명은 그대로 "modifiedAt"로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->