### PR TITLE
feat: 보관 카테고리 기능 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -197,7 +197,34 @@ Content-Type: application/json
     {
       "identifier": "abc123",
       "title": "워크스페이스 제목",
-      "modifiedAt": "2025-10-31T12:00:00"
+      "modifiedAt": "2025-10-31T12:00:00+09:00"
+    }
+  ]
+}
+```
+
+### 3.5 내 보관 카테고리 목록 조회
+
+현재 로그인한 사용자가 보관한 모든 카테고리 목록을 조회합니다.
+
+```http
+GET /api/me/saved-categories HTTP/1.1
+Authorization: Bearer {accessToken}
+```
+
+**성공 응답:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "savedCategories": [
+    {
+      "id": 1,
+      "name": "보관 카테고리 이름",
+      "placeCount": 3,
+      "modifiedAt": "2025-10-31T12:00:00+09:00"
     }
   ]
 }
@@ -226,6 +253,7 @@ Content-Type: application/json
   "searchedPlaces": [
     {
       "name": "장소 이름",
+      "url": "카카오 장소 URL",
       "roadAddressName": "도로명 주소",
       "addressName": "지번 주소",
       "latitude": 37.5665,
@@ -262,7 +290,7 @@ Content-Type: application/json
 {
   "identifier": "abc123",
   "title": "워크스페이스 제목",
-  "modifiedAt": "2025-10-31T12:00:00"
+  "modifiedAt": "2025-10-31T12:00:00+09:00"
 }
 ```
 
@@ -284,7 +312,7 @@ Content-Type: application/json
 {
   "identifier": "abc123",
   "title": "워크스페이스 제목",
-  "modifiedAt": "2025-10-31T12:00:00"
+  "modifiedAt": "2025-10-31T12:00:00+09:00"
 }
 ```
 
@@ -311,7 +339,7 @@ Content-Type: application/json
 {
   "identifier": "abc123",
   "title": "새로운 제목",
-  "modifiedAt": "2025-10-31T12:30:00"
+  "modifiedAt": "2025-10-31T12:30:00+09:00"
 }
 ```
 
@@ -402,11 +430,12 @@ Content-Type: application/json
       "color": "#FF5733",
       "sequence": 1,
       "representativePlaceId": 5,
-      "categoryPlacesResponse": {
-        "categoryPlaceResponses": [
+      "categoryPlaces": {
+        "categoryPlaces": [
           {
             "id": 5,
             "name": "장소 이름",
+            "placeUrl": "카카오 장소 URL",
             "addressName": "지번 주소",
             "roadAddressName": "도로명 주소",
             "latitude": 37.5665,
@@ -488,11 +517,12 @@ Content-Type: application/json
   "color": "#FF5733",
   "sequence": 1,
   "representativePlaceId": 5,
-  "categoryPlacesResponse": {
-    "categoryPlaceResponses": [
+  "categoryPlaces": {
+    "categoryPlaces": [
       {
         "id": 5,
         "name": "장소 이름",
+        "placeUrl": "카카오 장소 URL",
         "addressName": "지번 주소",
         "roadAddressName": "도로명 주소",
         "latitude": 37.5665,
@@ -603,6 +633,7 @@ Content-Type: application/json
 
 {
   "name": "장소 이름",
+  "placeUrl": "카카오 장소 URL",
   "roadAddressName": "도로명 주소",
   "addressName": "지번 주소",
   "latitude": 37.5665,
@@ -620,6 +651,7 @@ Content-Type: application/json
   "id": 5,
   "placeId": 10,
   "name": "장소 이름",
+  "placeUrl": "카카오 장소 URL",
   "roadAddressName": "도로명 주소",
   "addressName": "지번 주소",
   "latitude": 37.5665,
@@ -647,6 +679,7 @@ Content-Type: application/json
     {
       "id": 5,
       "name": "장소 이름",
+      "placeUrl": "카카오 장소 URL",
       "addressName": "지번 주소",
       "roadAddressName": "도로명 주소",
       "latitude": 37.5665,
@@ -674,14 +707,147 @@ HTTP/1.1 204 No Content
 
 ---
 
+## 8. 보관 카테고리 (Saved Category)
+
+### 8.1 보관 카테고리 생성
+
+새로운 보관 카테고리를 생성합니다. 생성 시 장소 목록을 함께 전달해야 합니다.
+
+```http
+POST /api/saved-categories HTTP/1.1
+Authorization: Bearer {accessToken}
+Content-Type: application/json
+
+{
+  "name": "보관 카테고리 이름",
+  "savedCategoryPlaces": [
+    {
+      "name": "장소 이름",
+      "placeUrl": "카카오 장소 URL",
+      "roadAddressName": "도로명 주소",
+      "addressName": "지번 주소",
+      "latitude": 37.5665,
+      "longitude": 126.9780
+    }
+  ]
+}
+```
+
+**성공 응답:**
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "id": 1,
+  "name": "보관 카테고리 이름"
+}
+```
+
+### 8.2 보관 카테고리 단건 조회
+
+특정 보관 카테고리의 상세 정보와 포함된 장소 목록을 조회합니다.
+
+```http
+GET /api/saved-categories/{savedCategoryId} HTTP/1.1
+Authorization: Bearer {accessToken}
+```
+
+**성공 응답:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": 1,
+  "name": "보관 카테고리 이름",
+  "savedCategoryPlaces": [
+    {
+      "id": 1,
+      "name": "장소 이름",
+      "placeUrl": "카카오 장소 URL",
+      "roadAddressName": "도로명 주소",
+      "addressName": "지번 주소",
+      "latitude": 37.5665,
+      "longitude": 126.9780
+    }
+  ]
+}
+```
+
+### 8.3 보관 카테고리 수정
+
+보관 카테고리의 이름과 장소 목록을 수정합니다. `savedCategoryPlaceId`가 있으면 기존 장소 유지, `null`이면 새 장소로 추가됩니다. 요청에 포함되지 않은 기존 장소는 삭제됩니다.
+
+```http
+PATCH /api/saved-categories/{savedCategoryId} HTTP/1.1
+Authorization: Bearer {accessToken}
+Content-Type: application/json
+
+{
+  "name": "새로운 카테고리 이름",
+  "savedCategoryPlaces": [
+    {
+      "savedCategoryPlaceId": 1,
+      "name": "기존 장소 이름",
+      "placeUrl": "카카오 장소 URL",
+      "roadAddressName": "도로명 주소",
+      "addressName": "지번 주소",
+      "latitude": 37.5665,
+      "longitude": 126.9780
+    },
+    {
+      "savedCategoryPlaceId": null,
+      "name": "새 장소 이름",
+      "placeUrl": "카카오 장소 URL",
+      "roadAddressName": "도로명 주소",
+      "addressName": "지번 주소",
+      "latitude": 37.1234,
+      "longitude": 127.1234
+    }
+  ]
+}
+```
+
+**성공 응답:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": 1,
+  "name": "새로운 카테고리 이름"
+}
+```
+
+### 8.4 보관 카테고리 삭제
+
+보관 카테고리를 삭제합니다. 포함된 모든 장소 정보도 함께 삭제됩니다.
+
+```http
+DELETE /api/saved-categories/{savedCategoryId} HTTP/1.1
+Authorization: Bearer {accessToken}
+```
+
+**성공 응답:**
+
+```http
+HTTP/1.1 204 No Content
+```
+
+---
+
 ## API 통계
 
-- **전체 엔드포인트**: 26개
+- **전체 엔드포인트**: 30개
 - **HTTP 메서드별**:
-    - GET: 11개
-    - POST: 8개
-    - PATCH: 2개
-    - DELETE: 4개
+    - GET: 14개
+    - POST: 7개
+    - PATCH: 3개
+    - DELETE: 5개
     - PUT: 1개
-- **인증 필요**: 19개
-- **공개 엔드포인트**: 7개
+- **인증 필요**: 26개
+- **공개 엔드포인트**: 4개

--- a/src/main/java/courseitda/common/exception/ErrorCode.java
+++ b/src/main/java/courseitda/common/exception/ErrorCode.java
@@ -364,6 +364,18 @@ public enum ErrorCode {
             HttpStatus.UNPROCESSABLE_ENTITY // 422
     ),
 
+    SAVED_CATEGORY_NOT_FOUND(
+            "7003",
+            "존재하지 않는 보관 카테고리 입니다.",
+            HttpStatus.NOT_FOUND // 404
+    ),
+
+    SAVED_CATEGORY_MODIFY_FORBIDDEN(
+            "7004",
+            "해당 보관 카테고리의 수정 권한이 없습니다.",
+            HttpStatus.FORBIDDEN // 403
+    ),
+
     ;
 
     private final String code;

--- a/src/main/java/courseitda/common/exception/ErrorCode.java
+++ b/src/main/java/courseitda/common/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
      * 4000 Series: Category Place Errors
      * 5000 Series: Member Errors
      * 6000 Series: Place Search Errors
+     * 7000 Series: SavedCategory Errors
      * */
 
     // TEMPORARY_ERROR - 0000
@@ -347,6 +348,20 @@ public enum ErrorCode {
             "6013",
             "검색된 장소의 URL은 null 또는 공백일 수 없습니다.",
             HttpStatus.BAD_GATEWAY // 502
+    ),
+
+    //-----------------------------------------------------------------------------------
+    // 7000 Series: SavedCategory Errors
+    SAVED_CATEGORY_NAME_EMPTY(
+            "7001",
+            "보관 카테고리 이름은 null 또는 공백일 수 없습니다.",
+            HttpStatus.BAD_REQUEST // 400
+    ),
+
+    SAVED_CATEGORY_NAME_LENGTH_EXCEEDED(
+            "7002",
+            "보관 카테고리 이름은 10자를 초과할 수 없습니다.",
+            HttpStatus.UNPROCESSABLE_ENTITY // 422
     ),
 
     ;

--- a/src/main/java/courseitda/member/application/MeService.java
+++ b/src/main/java/courseitda/member/application/MeService.java
@@ -1,17 +1,26 @@
 package courseitda.member.application;
 
+import courseitda.member.ui.dto.response.MySavedCategoriesResponse;
 import courseitda.member.ui.dto.response.MyWorkspacesResponse;
+import courseitda.mystorage.domain.SavedCategoryRepository;
 import courseitda.workspace.domain.WorkspaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MeService {
 
     private final WorkspaceRepository workspaceRepository;
+    private final SavedCategoryRepository savedCategoryRepository;
 
     public MyWorkspacesResponse readMyWorkspaces(final Long memberId) {
         return MyWorkspacesResponse.from(workspaceRepository.findAllByOwnerId(memberId));
+    }
+
+    @Transactional(readOnly = true)
+    public MySavedCategoriesResponse readMySavedCategory(final Long memberId) {
+        return MySavedCategoriesResponse.from(savedCategoryRepository.findAllByOwnerId(memberId));
     }
 }

--- a/src/main/java/courseitda/member/ui/MeController.java
+++ b/src/main/java/courseitda/member/ui/MeController.java
@@ -9,6 +9,7 @@ import courseitda.member.domain.Member;
 import courseitda.member.ui.dto.response.MemberDropdownResponse;
 import courseitda.member.ui.dto.response.MemberNavigatorResponse;
 import courseitda.member.ui.dto.response.MemberProfileResponse;
+import courseitda.member.ui.dto.response.MySavedCategoriesResponse;
 import courseitda.member.ui.dto.response.MyWorkspacesResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -60,6 +61,16 @@ public class MeController {
             final MemberAuthInfo memberAuthInfo
     ) {
         final var response = meService.readMyWorkspaces(memberAuthInfo.id());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/saved-categories")
+    // TODO: 페이징 고려 필요
+    public ResponseEntity<MySavedCategoriesResponse> readMySavedCategories(
+            final MemberAuthInfo memberAuthInfo
+    ) {
+        final var response = meService.readMySavedCategory(memberAuthInfo.id());
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/courseitda/member/ui/dto/response/MySavedCategoriesResponse.java
+++ b/src/main/java/courseitda/member/ui/dto/response/MySavedCategoriesResponse.java
@@ -1,0 +1,37 @@
+package courseitda.member.ui.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import courseitda.mystorage.domain.SavedCategory;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MySavedCategoriesResponse(
+        @JsonProperty("savedCategories") List<SavedCategoryResponse> savedCategoryResponses
+) {
+
+    public static MySavedCategoriesResponse from(final List<SavedCategory> savedCategories) {
+        final List<SavedCategoryResponse> savedCategoryResponses = savedCategories.stream()
+                .map(SavedCategoryResponse::from)
+                .toList();
+
+        return new MySavedCategoriesResponse(savedCategoryResponses);
+    }
+
+    public record SavedCategoryResponse(
+            Long id,
+            String name,
+            int placeCount,
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss+09:00") LocalDateTime modifiedAt
+    ) {
+
+        public static SavedCategoryResponse from(final SavedCategory savedCategory) {
+            return new SavedCategoryResponse(
+                    savedCategory.getId(),
+                    savedCategory.getName(),
+                    savedCategory.getSavedCategoryPlaces().size(),
+                    savedCategory.getModifiedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/courseitda/mystorage/application/SavedCategoryService.java
+++ b/src/main/java/courseitda/mystorage/application/SavedCategoryService.java
@@ -11,6 +11,7 @@ import courseitda.mystorage.domain.SavedCategoryRepository;
 import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest;
 import courseitda.mystorage.ui.dto.request.SavedCategoryUpdateRequest;
 import courseitda.mystorage.ui.dto.response.SavedCategoryCreateResponse;
+import courseitda.mystorage.ui.dto.response.SavedCategoryReadResponse;
 import courseitda.mystorage.ui.dto.response.SavedCategoryUpdateResponse;
 import courseitda.place.domain.Place;
 import courseitda.place.domain.PlaceRepository;
@@ -78,6 +79,17 @@ public class SavedCategoryService {
 
         savedCategoryPlaceRepository.deleteAllBySavedCategoryId(savedCategoryId);
         savedCategoryRepository.delete(savedCategory);
+    }
+
+    @Transactional(readOnly = true)
+    public SavedCategoryReadResponse findSavedCategory(
+            final MemberAuthInfo memberAuthInfo,
+            final Long savedCategoryId
+    ) {
+        final var savedCategory = getSavedCategoryById(savedCategoryId);
+        savedCategory.validateOwnership(memberAuthInfo.id());
+
+        return SavedCategoryReadResponse.from(savedCategory);
     }
 
     private void applyName(final String name, final SavedCategory savedCategory) {

--- a/src/main/java/courseitda/mystorage/application/SavedCategoryService.java
+++ b/src/main/java/courseitda/mystorage/application/SavedCategoryService.java
@@ -71,6 +71,15 @@ public class SavedCategoryService {
         return SavedCategoryUpdateResponse.from(savedCategory);
     }
 
+    @Transactional
+    public void deleteSavedCategory(final MemberAuthInfo memberAuthInfo, final Long savedCategoryId) {
+        final var savedCategory = getSavedCategoryById(savedCategoryId);
+        savedCategory.validateOwnership(memberAuthInfo.id());
+
+        savedCategoryPlaceRepository.deleteAllBySavedCategoryId(savedCategoryId);
+        savedCategoryRepository.delete(savedCategory);
+    }
+
     private void applyName(final String name, final SavedCategory savedCategory) {
         if (!savedCategory.getName().equals(name)) {
             savedCategory.updateName(name);

--- a/src/main/java/courseitda/mystorage/application/SavedCategoryService.java
+++ b/src/main/java/courseitda/mystorage/application/SavedCategoryService.java
@@ -1,0 +1,48 @@
+package courseitda.mystorage.application;
+
+import courseitda.member.domain.Member;
+import courseitda.mystorage.domain.SavedCategory;
+import courseitda.mystorage.domain.SavedCategoryPlace;
+import courseitda.mystorage.domain.SavedCategoryPlaceRepository;
+import courseitda.mystorage.domain.SavedCategoryRepository;
+import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest;
+import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest.SavedCategoryPlaceRequest;
+import courseitda.mystorage.ui.dto.response.SavedCategoryCreateResponse;
+import courseitda.place.domain.Place;
+import courseitda.place.domain.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SavedCategoryService {
+
+    private final SavedCategoryRepository savedCategoryRepository;
+    private final SavedCategoryPlaceRepository savedCategoryPlaceRepository;
+    private final PlaceRepository placeRepository;
+
+    @Transactional
+    public SavedCategoryCreateResponse createSavedCategory(
+            final SavedCategoryCreateRequest request,
+            final Member member
+    ) {
+        final var newSavedCategory = SavedCategory.createNew(member, request.name());
+        final var persistedSavedCategory = savedCategoryRepository.save(newSavedCategory);
+
+        for (final SavedCategoryPlaceRequest placeRequest : request.savedCategoryPlaces()) {
+            final var newPlace = Place.createNew(
+                    placeRequest.name(),
+                    placeRequest.placeUrl(),
+                    placeRequest.roadAddressName(),
+                    placeRequest.addressName(),
+                    placeRequest.latitude(),
+                    placeRequest.longitude()
+            );
+            final var persistedPlace = placeRepository.save(newPlace);
+            savedCategoryPlaceRepository.save(SavedCategoryPlace.createNew(persistedSavedCategory, persistedPlace));
+        }
+
+        return SavedCategoryCreateResponse.from(persistedSavedCategory);
+    }
+}

--- a/src/main/java/courseitda/mystorage/application/SavedCategoryService.java
+++ b/src/main/java/courseitda/mystorage/application/SavedCategoryService.java
@@ -1,15 +1,23 @@
 package courseitda.mystorage.application;
 
+import courseitda.auth.domain.MemberAuthInfo;
+import courseitda.common.exception.BusinessException;
+import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.Member;
 import courseitda.mystorage.domain.SavedCategory;
 import courseitda.mystorage.domain.SavedCategoryPlace;
 import courseitda.mystorage.domain.SavedCategoryPlaceRepository;
 import courseitda.mystorage.domain.SavedCategoryRepository;
 import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest;
-import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest.SavedCategoryPlaceRequest;
+import courseitda.mystorage.ui.dto.request.SavedCategoryUpdateRequest;
 import courseitda.mystorage.ui.dto.response.SavedCategoryCreateResponse;
+import courseitda.mystorage.ui.dto.response.SavedCategoryUpdateResponse;
 import courseitda.place.domain.Place;
 import courseitda.place.domain.PlaceRepository;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +38,7 @@ public class SavedCategoryService {
         final var newSavedCategory = SavedCategory.createNew(member, request.name());
         final var persistedSavedCategory = savedCategoryRepository.save(newSavedCategory);
 
-        for (final SavedCategoryPlaceRequest placeRequest : request.savedCategoryPlaces()) {
+        for (final var placeRequest : request.savedCategoryPlaces()) {
             final var newPlace = Place.createNew(
                     placeRequest.name(),
                     placeRequest.placeUrl(),
@@ -43,6 +51,83 @@ public class SavedCategoryService {
             savedCategoryPlaceRepository.save(SavedCategoryPlace.createNew(persistedSavedCategory, persistedPlace));
         }
 
+        // 주의: savedCategoryPlaces 응답에 포함 시 getSavedCategoryById()로 재조회 필요 (JPA 1차 캐시 불일치)
         return SavedCategoryCreateResponse.from(persistedSavedCategory);
+    }
+
+    @Transactional
+    public SavedCategoryUpdateResponse updateSavedCategory(
+            final SavedCategoryUpdateRequest request,
+            final MemberAuthInfo memberAuthInfo,
+            final Long savedCategoryId
+    ) {
+        final var savedCategory = getSavedCategoryById(savedCategoryId);
+        savedCategory.validateOwnership(memberAuthInfo.id());
+
+        applyName(request.name(), savedCategory);
+        syncSavedCategoryPlaces(request.savedCategoryPlaces(), savedCategory);
+
+        // 주의: savedCategoryPlaces 응답에 포함 시 getSavedCategoryById()로 재조회 필요 (JPA 1차 캐시 불일치)
+        return SavedCategoryUpdateResponse.from(savedCategory);
+    }
+
+    private void applyName(final String name, final SavedCategory savedCategory) {
+        if (!savedCategory.getName().equals(name)) {
+            savedCategory.updateName(name);
+        }
+    }
+
+    private void syncSavedCategoryPlaces(
+            final List<SavedCategoryUpdateRequest.SavedCategoryPlaceRequest> placeRequests,
+            final SavedCategory savedCategory
+    ) {
+        removeMissingSavedCategoryPlaces(placeRequests, savedCategory);
+        addNewSavedCategoryPlaces(placeRequests, savedCategory);
+    }
+
+    private void removeMissingSavedCategoryPlaces(
+            final List<SavedCategoryUpdateRequest.SavedCategoryPlaceRequest> placeRequests,
+            final SavedCategory savedCategory
+    ) {
+        final Set<Long> requestPlaceIdSet = placeRequests.stream()
+                .map(SavedCategoryUpdateRequest.SavedCategoryPlaceRequest::savedCategoryPlaceId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        final var existingPlaces = savedCategoryPlaceRepository.findAllBySavedCategoryId(savedCategory.getId());
+        final var existingPlaceIds = existingPlaces.stream()
+                .map(SavedCategoryPlace::getId)
+                .toList();
+
+        final var idsToDelete = existingPlaceIds.stream()
+                .filter(id -> !requestPlaceIdSet.contains(id))
+                .toList();
+        savedCategoryPlaceRepository.deleteAllByIds(idsToDelete);
+    }
+
+    private void addNewSavedCategoryPlaces(
+            final List<SavedCategoryUpdateRequest.SavedCategoryPlaceRequest> placeRequests,
+            final SavedCategory savedCategory
+    ) {
+        for (final var placeRequest : placeRequests) {
+            if (placeRequest.savedCategoryPlaceId() == null) {
+                final var newPlace = Place.createNew(
+                        placeRequest.name(),
+                        placeRequest.placeUrl(),
+                        placeRequest.roadAddressName(),
+                        placeRequest.addressName(),
+                        placeRequest.latitude(),
+                        placeRequest.longitude()
+                );
+                final var persistedPlace = placeRepository.save(newPlace);
+                final var newSavedCategoryPlace = SavedCategoryPlace.createNew(savedCategory, persistedPlace);
+                savedCategoryPlaceRepository.save(newSavedCategoryPlace);
+            }
+        }
+    }
+
+    private SavedCategory getSavedCategoryById(final Long savedCategoryId) {
+        return savedCategoryRepository.findById(savedCategoryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SAVED_CATEGORY_NOT_FOUND));
     }
 }

--- a/src/main/java/courseitda/mystorage/application/SavedCategoryService.java
+++ b/src/main/java/courseitda/mystorage/application/SavedCategoryService.java
@@ -93,7 +93,7 @@ public class SavedCategoryService {
     }
 
     private void applyName(final String name, final SavedCategory savedCategory) {
-        if (!savedCategory.getName().equals(name)) {
+        if (!Objects.equals(savedCategory.getName(), name)) {
             savedCategory.updateName(name);
         }
     }

--- a/src/main/java/courseitda/mystorage/domain/SavedCategory.java
+++ b/src/main/java/courseitda/mystorage/domain/SavedCategory.java
@@ -15,6 +15,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -55,6 +56,17 @@ public class SavedCategory extends Timestamp {
 
     public static SavedCategory createNew(final Member owner, final String name) {
         return new SavedCategory(owner, name, new ArrayList<>());
+    }
+
+    public void updateName(final String newName) {
+        validateName(newName);
+        this.name = newName;
+    }
+
+    public void validateOwnership(final Long memberId) {
+        if (!Objects.equals(this.owner.getId(), memberId)) {
+            throw new BusinessException(ErrorCode.SAVED_CATEGORY_MODIFY_FORBIDDEN);
+        }
     }
 
     private void validateName(final String name) {

--- a/src/main/java/courseitda/mystorage/domain/SavedCategory.java
+++ b/src/main/java/courseitda/mystorage/domain/SavedCategory.java
@@ -1,6 +1,8 @@
 package courseitda.mystorage.domain;
 
 import courseitda.common.entity.Timestamp;
+import courseitda.common.exception.BusinessException;
+import courseitda.common.exception.ErrorCode;
 import courseitda.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -37,4 +40,29 @@ public class SavedCategory extends Timestamp {
 
     @OneToMany(mappedBy = "savedCategory")
     private List<SavedCategoryPlace> savedCategoryPlaces;
+
+    public SavedCategory(
+            final Member owner,
+            final String name,
+            final List<SavedCategoryPlace> savedCategoryPlaces
+    ) {
+        validateName(name);
+
+        this.owner = owner;
+        this.name = name;
+        this.savedCategoryPlaces = savedCategoryPlaces;
+    }
+
+    public static SavedCategory createNew(final Member owner, final String name) {
+        return new SavedCategory(owner, name, new ArrayList<>());
+    }
+
+    private void validateName(final String name) {
+        if (name == null || name.isBlank()) {
+            throw new BusinessException(ErrorCode.SAVED_CATEGORY_NAME_EMPTY);
+        }
+        if (name.length() > 10) {
+            throw new BusinessException(ErrorCode.SAVED_CATEGORY_NAME_LENGTH_EXCEEDED);
+        }
+    }
 }

--- a/src/main/java/courseitda/mystorage/domain/SavedCategoryPlace.java
+++ b/src/main/java/courseitda/mystorage/domain/SavedCategoryPlace.java
@@ -31,4 +31,16 @@ public class SavedCategoryPlace {
     @ManyToOne
     @JoinColumn(nullable = false)
     private Place place;
+
+    public SavedCategoryPlace(
+            final SavedCategory savedCategory,
+            final Place place
+    ) {
+        this.savedCategory = savedCategory;
+        this.place = place;
+    }
+
+    public static SavedCategoryPlace createNew(final SavedCategory savedCategory, final Place place) {
+        return new SavedCategoryPlace(savedCategory, place);
+    }
 }

--- a/src/main/java/courseitda/mystorage/domain/SavedCategoryPlaceRepository.java
+++ b/src/main/java/courseitda/mystorage/domain/SavedCategoryPlaceRepository.java
@@ -9,4 +9,6 @@ public interface SavedCategoryPlaceRepository {
     List<SavedCategoryPlace> findAllBySavedCategoryId(Long savedCategoryId);
 
     void deleteAllByIds(List<Long> ids);
+
+    void deleteAllBySavedCategoryId(Long savedCategoryId);
 }

--- a/src/main/java/courseitda/mystorage/domain/SavedCategoryPlaceRepository.java
+++ b/src/main/java/courseitda/mystorage/domain/SavedCategoryPlaceRepository.java
@@ -1,0 +1,6 @@
+package courseitda.mystorage.domain;
+
+public interface SavedCategoryPlaceRepository {
+
+    SavedCategoryPlace save(SavedCategoryPlace savedCategoryPlace);
+}

--- a/src/main/java/courseitda/mystorage/domain/SavedCategoryPlaceRepository.java
+++ b/src/main/java/courseitda/mystorage/domain/SavedCategoryPlaceRepository.java
@@ -1,6 +1,12 @@
 package courseitda.mystorage.domain;
 
+import java.util.List;
+
 public interface SavedCategoryPlaceRepository {
 
     SavedCategoryPlace save(SavedCategoryPlace savedCategoryPlace);
+
+    List<SavedCategoryPlace> findAllBySavedCategoryId(Long savedCategoryId);
+
+    void deleteAllByIds(List<Long> ids);
 }

--- a/src/main/java/courseitda/mystorage/domain/SavedCategoryRepository.java
+++ b/src/main/java/courseitda/mystorage/domain/SavedCategoryRepository.java
@@ -7,4 +7,6 @@ public interface SavedCategoryRepository {
     SavedCategory save(SavedCategory savedCategory);
 
     Optional<SavedCategory> findById(Long savedCategoryId);
+
+    void delete(SavedCategory savedCategory);
 }

--- a/src/main/java/courseitda/mystorage/domain/SavedCategoryRepository.java
+++ b/src/main/java/courseitda/mystorage/domain/SavedCategoryRepository.java
@@ -1,6 +1,10 @@
 package courseitda.mystorage.domain;
 
+import java.util.Optional;
+
 public interface SavedCategoryRepository {
 
     SavedCategory save(SavedCategory savedCategory);
+
+    Optional<SavedCategory> findById(Long savedCategoryId);
 }

--- a/src/main/java/courseitda/mystorage/domain/SavedCategoryRepository.java
+++ b/src/main/java/courseitda/mystorage/domain/SavedCategoryRepository.java
@@ -1,0 +1,6 @@
+package courseitda.mystorage.domain;
+
+public interface SavedCategoryRepository {
+
+    SavedCategory save(SavedCategory savedCategory);
+}

--- a/src/main/java/courseitda/mystorage/domain/SavedCategoryRepository.java
+++ b/src/main/java/courseitda/mystorage/domain/SavedCategoryRepository.java
@@ -1,5 +1,6 @@
 package courseitda.mystorage.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SavedCategoryRepository {
@@ -9,4 +10,6 @@ public interface SavedCategoryRepository {
     Optional<SavedCategory> findById(Long savedCategoryId);
 
     void delete(SavedCategory savedCategory);
+
+    List<SavedCategory> findAllByOwnerId(Long ownerId);
 }

--- a/src/main/java/courseitda/mystorage/infrastructure/JpaSavedCategoryPlaceRepository.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/JpaSavedCategoryPlaceRepository.java
@@ -1,0 +1,7 @@
+package courseitda.mystorage.infrastructure;
+
+import courseitda.mystorage.domain.SavedCategoryPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaSavedCategoryPlaceRepository extends JpaRepository<SavedCategoryPlace, Long> {
+}

--- a/src/main/java/courseitda/mystorage/infrastructure/JpaSavedCategoryPlaceRepository.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/JpaSavedCategoryPlaceRepository.java
@@ -1,7 +1,12 @@
 package courseitda.mystorage.infrastructure;
 
 import courseitda.mystorage.domain.SavedCategoryPlace;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaSavedCategoryPlaceRepository extends JpaRepository<SavedCategoryPlace, Long> {
+
+    List<SavedCategoryPlace> findAllBySavedCategoryId(Long savedCategoryId);
+
+    void deleteAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/courseitda/mystorage/infrastructure/JpaSavedCategoryPlaceRepository.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/JpaSavedCategoryPlaceRepository.java
@@ -9,4 +9,6 @@ public interface JpaSavedCategoryPlaceRepository extends JpaRepository<SavedCate
     List<SavedCategoryPlace> findAllBySavedCategoryId(Long savedCategoryId);
 
     void deleteAllByIdIn(List<Long> ids);
+
+    void deleteAllBySavedCategoryId(Long savedCategoryId);
 }

--- a/src/main/java/courseitda/mystorage/infrastructure/JpaSavedCategoryRepository.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/JpaSavedCategoryRepository.java
@@ -1,0 +1,7 @@
+package courseitda.mystorage.infrastructure;
+
+import courseitda.mystorage.domain.SavedCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaSavedCategoryRepository extends JpaRepository<SavedCategory, Long> {
+}

--- a/src/main/java/courseitda/mystorage/infrastructure/JpaSavedCategoryRepository.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/JpaSavedCategoryRepository.java
@@ -1,7 +1,10 @@
 package courseitda.mystorage.infrastructure;
 
 import courseitda.mystorage.domain.SavedCategory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaSavedCategoryRepository extends JpaRepository<SavedCategory, Long> {
+
+    List<SavedCategory> findAllByOwnerId(Long ownerId);
 }

--- a/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryPlaceRepositoryImpl.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryPlaceRepositoryImpl.java
@@ -2,6 +2,7 @@ package courseitda.mystorage.infrastructure;
 
 import courseitda.mystorage.domain.SavedCategoryPlace;
 import courseitda.mystorage.domain.SavedCategoryPlaceRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,17 @@ public class SavedCategoryPlaceRepositoryImpl implements SavedCategoryPlaceRepos
     @Override
     public SavedCategoryPlace save(final SavedCategoryPlace savedCategoryPlace) {
         return jpaSavedCategoryPlaceRepository.save(savedCategoryPlace);
+    }
+
+    @Override
+    public List<SavedCategoryPlace> findAllBySavedCategoryId(final Long savedCategoryId) {
+        return jpaSavedCategoryPlaceRepository.findAllBySavedCategoryId(savedCategoryId);
+    }
+
+    @Override
+    public void deleteAllByIds(final List<Long> ids) {
+        if (!ids.isEmpty()) {
+            jpaSavedCategoryPlaceRepository.deleteAllByIdIn(ids);
+        }
     }
 }

--- a/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryPlaceRepositoryImpl.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryPlaceRepositoryImpl.java
@@ -1,0 +1,18 @@
+package courseitda.mystorage.infrastructure;
+
+import courseitda.mystorage.domain.SavedCategoryPlace;
+import courseitda.mystorage.domain.SavedCategoryPlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SavedCategoryPlaceRepositoryImpl implements SavedCategoryPlaceRepository {
+
+    private final JpaSavedCategoryPlaceRepository jpaSavedCategoryPlaceRepository;
+
+    @Override
+    public SavedCategoryPlace save(final SavedCategoryPlace savedCategoryPlace) {
+        return jpaSavedCategoryPlaceRepository.save(savedCategoryPlace);
+    }
+}

--- a/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryPlaceRepositoryImpl.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryPlaceRepositoryImpl.java
@@ -28,4 +28,9 @@ public class SavedCategoryPlaceRepositoryImpl implements SavedCategoryPlaceRepos
             jpaSavedCategoryPlaceRepository.deleteAllByIdIn(ids);
         }
     }
+
+    @Override
+    public void deleteAllBySavedCategoryId(final Long savedCategoryId) {
+        jpaSavedCategoryPlaceRepository.deleteAllBySavedCategoryId(savedCategoryId);
+    }
 }

--- a/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryRepositoryImpl.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryRepositoryImpl.java
@@ -2,6 +2,7 @@ package courseitda.mystorage.infrastructure;
 
 import courseitda.mystorage.domain.SavedCategory;
 import courseitda.mystorage.domain.SavedCategoryRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -25,5 +26,10 @@ public class SavedCategoryRepositoryImpl implements SavedCategoryRepository {
     @Override
     public void delete(final SavedCategory savedCategory) {
         jpaSavedCategoryRepository.delete(savedCategory);
+    }
+
+    @Override
+    public List<SavedCategory> findAllByOwnerId(Long ownerId) {
+        return jpaSavedCategoryRepository.findAllByOwnerId(ownerId);
     }
 }

--- a/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryRepositoryImpl.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryRepositoryImpl.java
@@ -1,0 +1,18 @@
+package courseitda.mystorage.infrastructure;
+
+import courseitda.mystorage.domain.SavedCategory;
+import courseitda.mystorage.domain.SavedCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SavedCategoryRepositoryImpl implements SavedCategoryRepository {
+
+    private final JpaSavedCategoryRepository jpaSavedCategoryRepository;
+
+    @Override
+    public SavedCategory save(final SavedCategory savedCategory) {
+        return jpaSavedCategoryRepository.save(savedCategory);
+    }
+}

--- a/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryRepositoryImpl.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryRepositoryImpl.java
@@ -21,4 +21,9 @@ public class SavedCategoryRepositoryImpl implements SavedCategoryRepository {
     public Optional<SavedCategory> findById(final Long savedCategoryId) {
         return jpaSavedCategoryRepository.findById(savedCategoryId);
     }
+
+    @Override
+    public void delete(final SavedCategory savedCategory) {
+        jpaSavedCategoryRepository.delete(savedCategory);
+    }
 }

--- a/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryRepositoryImpl.java
+++ b/src/main/java/courseitda/mystorage/infrastructure/SavedCategoryRepositoryImpl.java
@@ -2,6 +2,7 @@ package courseitda.mystorage.infrastructure;
 
 import courseitda.mystorage.domain.SavedCategory;
 import courseitda.mystorage.domain.SavedCategoryRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,10 @@ public class SavedCategoryRepositoryImpl implements SavedCategoryRepository {
     @Override
     public SavedCategory save(final SavedCategory savedCategory) {
         return jpaSavedCategoryRepository.save(savedCategory);
+    }
+
+    @Override
+    public Optional<SavedCategory> findById(final Long savedCategoryId) {
+        return jpaSavedCategoryRepository.findById(savedCategoryId);
     }
 }

--- a/src/main/java/courseitda/mystorage/ui/SavedCategoryController.java
+++ b/src/main/java/courseitda/mystorage/ui/SavedCategoryController.java
@@ -1,15 +1,20 @@
 package courseitda.mystorage.ui;
 
 import courseitda.auth.domain.AuthRole;
+import courseitda.auth.domain.MemberAuthInfo;
 import courseitda.auth.domain.RequiresRole;
 import courseitda.member.domain.Member;
 import courseitda.mystorage.application.SavedCategoryService;
 import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest;
+import courseitda.mystorage.ui.dto.request.SavedCategoryUpdateRequest;
 import courseitda.mystorage.ui.dto.response.SavedCategoryCreateResponse;
+import courseitda.mystorage.ui.dto.response.SavedCategoryUpdateResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,5 +37,16 @@ public class SavedCategoryController {
 
         return ResponseEntity.created(URI.create("/api/saved-categories/" + response.id()))
                 .body(response);
+    }
+
+    @PatchMapping("/{savedCategoryId}")
+    public ResponseEntity<SavedCategoryUpdateResponse> updateSavedCategory(
+            final MemberAuthInfo memberAuthInfo,
+            @PathVariable final Long savedCategoryId,
+            @Valid @RequestBody final SavedCategoryUpdateRequest request
+    ) {
+        final var response = savedCategoryService.updateSavedCategory(request, memberAuthInfo, savedCategoryId);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/courseitda/mystorage/ui/SavedCategoryController.java
+++ b/src/main/java/courseitda/mystorage/ui/SavedCategoryController.java
@@ -8,12 +8,14 @@ import courseitda.mystorage.application.SavedCategoryService;
 import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest;
 import courseitda.mystorage.ui.dto.request.SavedCategoryUpdateRequest;
 import courseitda.mystorage.ui.dto.response.SavedCategoryCreateResponse;
+import courseitda.mystorage.ui.dto.response.SavedCategoryReadResponse;
 import courseitda.mystorage.ui.dto.response.SavedCategoryUpdateResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -59,5 +61,15 @@ public class SavedCategoryController {
         savedCategoryService.deleteSavedCategory(memberAuthInfo, savedCategoryId);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{savedCategoryId}")
+    public ResponseEntity<SavedCategoryReadResponse> readSavedCategory(
+            final MemberAuthInfo memberAuthInfo,
+            @PathVariable final Long savedCategoryId
+    ) {
+        final var response = savedCategoryService.findSavedCategory(memberAuthInfo, savedCategoryId);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/courseitda/mystorage/ui/SavedCategoryController.java
+++ b/src/main/java/courseitda/mystorage/ui/SavedCategoryController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,5 +49,15 @@ public class SavedCategoryController {
         final var response = savedCategoryService.updateSavedCategory(request, memberAuthInfo, savedCategoryId);
 
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{savedCategoryId}")
+    public ResponseEntity<Void> deleteSavedCategory(
+            final MemberAuthInfo memberAuthInfo,
+            @PathVariable final Long savedCategoryId
+    ) {
+        savedCategoryService.deleteSavedCategory(memberAuthInfo, savedCategoryId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/courseitda/mystorage/ui/SavedCategoryController.java
+++ b/src/main/java/courseitda/mystorage/ui/SavedCategoryController.java
@@ -1,0 +1,36 @@
+package courseitda.mystorage.ui;
+
+import courseitda.auth.domain.AuthRole;
+import courseitda.auth.domain.RequiresRole;
+import courseitda.member.domain.Member;
+import courseitda.mystorage.application.SavedCategoryService;
+import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest;
+import courseitda.mystorage.ui.dto.response.SavedCategoryCreateResponse;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/saved-categories")
+@RequiresRole(authRoles = {AuthRole.MEMBER})
+public class SavedCategoryController {
+
+    private final SavedCategoryService savedCategoryService;
+
+    @PostMapping
+    public ResponseEntity<SavedCategoryCreateResponse> createSavedCategory(
+            final Member member,
+            @Valid @RequestBody final SavedCategoryCreateRequest request
+    ) {
+        final var response = savedCategoryService.createSavedCategory(request, member);
+
+        return ResponseEntity.created(URI.create("/api/saved-categories/" + response.id()))
+                .body(response);
+    }
+}

--- a/src/main/java/courseitda/mystorage/ui/dto/request/SavedCategoryCreateRequest.java
+++ b/src/main/java/courseitda/mystorage/ui/dto/request/SavedCategoryCreateRequest.java
@@ -1,0 +1,22 @@
+package courseitda.mystorage.ui.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record SavedCategoryCreateRequest(
+        @NotBlank String name,
+        @NotEmpty @Valid List<SavedCategoryPlaceRequest> savedCategoryPlaces
+) {
+
+    public record SavedCategoryPlaceRequest(
+            @NotBlank String name,
+            @NotBlank String placeUrl,
+            String roadAddressName,
+            @NotBlank String addressName,
+            double latitude,
+            double longitude
+    ) {
+    }
+}

--- a/src/main/java/courseitda/mystorage/ui/dto/request/SavedCategoryUpdateRequest.java
+++ b/src/main/java/courseitda/mystorage/ui/dto/request/SavedCategoryUpdateRequest.java
@@ -1,0 +1,23 @@
+package courseitda.mystorage.ui.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record SavedCategoryUpdateRequest(
+        @NotBlank String name,
+        @NotEmpty @Valid List<SavedCategoryPlaceRequest> savedCategoryPlaces
+) {
+
+    public record SavedCategoryPlaceRequest(
+            Long savedCategoryPlaceId, // nullable
+            @NotBlank String name,
+            @NotBlank String placeUrl,
+            String roadAddressName,
+            @NotBlank String addressName,
+            double latitude,
+            double longitude
+    ) {
+    }
+}

--- a/src/main/java/courseitda/mystorage/ui/dto/response/SavedCategoryCreateResponse.java
+++ b/src/main/java/courseitda/mystorage/ui/dto/response/SavedCategoryCreateResponse.java
@@ -1,0 +1,16 @@
+package courseitda.mystorage.ui.dto.response;
+
+import courseitda.mystorage.domain.SavedCategory;
+
+public record SavedCategoryCreateResponse(
+        Long id,
+        String name
+) {
+
+    public static SavedCategoryCreateResponse from(final SavedCategory savedCategory) {
+        return new SavedCategoryCreateResponse(
+                savedCategory.getId(),
+                savedCategory.getName()
+        );
+    }
+}

--- a/src/main/java/courseitda/mystorage/ui/dto/response/SavedCategoryReadResponse.java
+++ b/src/main/java/courseitda/mystorage/ui/dto/response/SavedCategoryReadResponse.java
@@ -1,0 +1,46 @@
+package courseitda.mystorage.ui.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import courseitda.mystorage.domain.SavedCategory;
+import courseitda.mystorage.domain.SavedCategoryPlace;
+import java.util.List;
+
+public record SavedCategoryReadResponse(
+        Long id,
+        String name,
+        @JsonProperty("savedCategoryPlaces") List<SavedCategoryPlaceResponse> savedCategoryPlaceResponses
+) {
+
+    public static SavedCategoryReadResponse from(final SavedCategory savedCategory) {
+        return new SavedCategoryReadResponse(
+                savedCategory.getId(),
+                savedCategory.getName(),
+                savedCategory.getSavedCategoryPlaces().stream()
+                        .map(SavedCategoryPlaceResponse::from)
+                        .toList()
+        );
+    }
+
+    public record SavedCategoryPlaceResponse(
+            Long id,
+            String name,
+            String placeUrl,
+            String roadAddressName,
+            String addressName,
+            double latitude,
+            double longitude
+    ) {
+
+        public static SavedCategoryPlaceResponse from(final SavedCategoryPlace savedCategoryPlace) {
+            return new SavedCategoryPlaceResponse(
+                    savedCategoryPlace.getId(),
+                    savedCategoryPlace.getPlace().getName(),
+                    savedCategoryPlace.getPlace().getPlaceUrl(),
+                    savedCategoryPlace.getPlace().getRoadAddressName(),
+                    savedCategoryPlace.getPlace().getAddressName(),
+                    savedCategoryPlace.getPlace().getLatitude(),
+                    savedCategoryPlace.getPlace().getLongitude()
+            );
+        }
+    }
+}

--- a/src/main/java/courseitda/mystorage/ui/dto/response/SavedCategoryUpdateResponse.java
+++ b/src/main/java/courseitda/mystorage/ui/dto/response/SavedCategoryUpdateResponse.java
@@ -1,0 +1,16 @@
+package courseitda.mystorage.ui.dto.response;
+
+import courseitda.mystorage.domain.SavedCategory;
+
+public record SavedCategoryUpdateResponse(
+        Long id,
+        String name
+) {
+
+    public static SavedCategoryUpdateResponse from(final SavedCategory savedCategory) {
+        return new SavedCategoryUpdateResponse(
+                savedCategory.getId(),
+                savedCategory.getName()
+        );
+    }
+}

--- a/src/test/java/courseitda/member/ui/MeControllerTest.java
+++ b/src/test/java/courseitda/member/ui/MeControllerTest.java
@@ -4,6 +4,8 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
+import java.util.List;
+
 import courseitda.auth.ui.dto.request.LoginRequest;
 import courseitda.auth.ui.dto.response.LoginResponse;
 import courseitda.member.domain.MemberFixture;
@@ -11,7 +13,12 @@ import courseitda.member.ui.dto.request.SignUpRequest;
 import courseitda.member.ui.dto.response.MemberDropdownResponse;
 import courseitda.member.ui.dto.response.MemberNavigatorResponse;
 import courseitda.member.ui.dto.response.MemberProfileResponse;
+import courseitda.member.ui.dto.response.MySavedCategoriesResponse;
 import courseitda.member.ui.dto.response.MyWorkspacesResponse;
+import courseitda.mystorage.domain.SavedCategoryFixture;
+import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest;
+import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest.SavedCategoryPlaceRequest;
+import courseitda.place.domain.PlaceFixture;
 import courseitda.workspace.domain.WorkspaceFixture;
 import courseitda.workspace.ui.dto.request.WorkspaceCreateRequest;
 import courseitda.workspace.ui.dto.response.WorkspaceCreateResponse;
@@ -68,6 +75,29 @@ class MeControllerTest {
         return loginResponse.tokenType() + " " + loginResponse.accessToken();
     }
 
+    private void createSavedCategory(final String accessToken) {
+        final SavedCategoryCreateRequest request = new SavedCategoryCreateRequest(
+                SavedCategoryFixture.anyName(),
+                List.of(new SavedCategoryPlaceRequest(
+                        PlaceFixture.anyName(),
+                        PlaceFixture.anyPlaceUrl(),
+                        PlaceFixture.anyRoadAddressName(),
+                        PlaceFixture.anyAddressName(),
+                        PlaceFixture.anyLatitude(),
+                        PlaceFixture.anyLongitude()
+                ))
+        );
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(request)
+                .when()
+                .post("/api/saved-categories")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
     private String createWorkspace(final String accessToken) {
         final String title = WorkspaceFixture.anyTitle();
         final WorkspaceCreateRequest request = new WorkspaceCreateRequest(title);
@@ -83,6 +113,55 @@ class MeControllerTest {
                 .extract()
                 .as(WorkspaceCreateResponse.class)
                 .identifier();
+    }
+
+    @Nested
+    @DisplayName("내 보관 카테고리 목록 조회 성공 시나리오")
+    class ReadMySavedCategoriesSuccessScenarios {
+
+        @Test
+        @DisplayName("내 보관 카테고리 목록 조회에 성공한다")
+        void readMySavedCategories_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            createSavedCategory(accessToken);
+            createSavedCategory(accessToken);
+
+            // when
+            final MySavedCategoriesResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/me/saved-categories")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(MySavedCategoriesResponse.class);
+
+            // then
+            assertThat(response.savedCategoryResponses()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("보관 카테고리가 없는 경우 빈 목록이 반환된다")
+        void readMySavedCategories_success_emptyList() {
+            // given
+            final String accessToken = signUpAndLogin();
+
+            // when
+            final MySavedCategoriesResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/me/saved-categories")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(MySavedCategoriesResponse.class);
+
+            // then
+            assertThat(response.savedCategoryResponses()).isEmpty();
+        }
     }
 
     @Nested

--- a/src/test/java/courseitda/mystorage/domain/SavedCategoryBuilder.java
+++ b/src/test/java/courseitda/mystorage/domain/SavedCategoryBuilder.java
@@ -1,0 +1,24 @@
+package courseitda.mystorage.domain;
+
+import courseitda.member.domain.Member;
+import courseitda.member.domain.MemberFixture;
+
+public class SavedCategoryBuilder {
+
+    private Member owner = MemberFixture.anyMember();
+    private String name = SavedCategoryFixture.anyName();
+
+    public SavedCategoryBuilder owner(final Member owner) {
+        this.owner = owner;
+        return this;
+    }
+
+    public SavedCategoryBuilder name(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    public SavedCategory build() {
+        return SavedCategory.createNew(owner, name);
+    }
+}

--- a/src/test/java/courseitda/mystorage/domain/SavedCategoryFixture.java
+++ b/src/test/java/courseitda/mystorage/domain/SavedCategoryFixture.java
@@ -1,0 +1,16 @@
+package courseitda.mystorage.domain;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class SavedCategoryFixture {
+
+    private static final AtomicLong sequenceName = new AtomicLong(0L);
+
+    public static String anyName() {
+        return "saved" + sequenceName.incrementAndGet();
+    }
+
+    public static SavedCategory anySavedCategory() {
+        return new SavedCategoryBuilder().build();
+    }
+}

--- a/src/test/java/courseitda/mystorage/ui/SavedCategoryControllerTest.java
+++ b/src/test/java/courseitda/mystorage/ui/SavedCategoryControllerTest.java
@@ -1,0 +1,619 @@
+package courseitda.mystorage.ui;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+import courseitda.auth.ui.dto.request.LoginRequest;
+import courseitda.auth.ui.dto.response.LoginResponse;
+import courseitda.common.exception.ErrorCode;
+import courseitda.member.domain.MemberFixture;
+import courseitda.member.ui.dto.request.SignUpRequest;
+import courseitda.mystorage.domain.SavedCategoryFixture;
+import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest;
+import courseitda.mystorage.ui.dto.request.SavedCategoryCreateRequest.SavedCategoryPlaceRequest;
+import courseitda.mystorage.ui.dto.request.SavedCategoryUpdateRequest;
+import courseitda.mystorage.ui.dto.response.SavedCategoryCreateResponse;
+import courseitda.mystorage.ui.dto.response.SavedCategoryReadResponse;
+import courseitda.mystorage.ui.dto.response.SavedCategoryUpdateResponse;
+import courseitda.place.domain.PlaceFixture;
+import io.restassured.RestAssured;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class SavedCategoryControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    private String signUpAndLogin() {
+        final String email = MemberFixture.anyEmail();
+        final String password = MemberFixture.anyPassword();
+        final String nickname = MemberFixture.anyNickname();
+        final SignUpRequest signUpRequest = new SignUpRequest(nickname, email, password);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(signUpRequest)
+                .when()
+                .post("/api/members")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+
+        final LoginRequest loginRequest = new LoginRequest(email, password);
+        final LoginResponse loginResponse = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(loginRequest)
+                .when()
+                .post("/api/auth/login")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(LoginResponse.class);
+
+        return loginResponse.tokenType() + " " + loginResponse.accessToken();
+    }
+
+    private SavedCategoryPlaceRequest anyPlaceRequest() {
+        return new SavedCategoryPlaceRequest(
+                PlaceFixture.anyName(),
+                PlaceFixture.anyPlaceUrl(),
+                PlaceFixture.anyRoadAddressName(),
+                PlaceFixture.anyAddressName(),
+                PlaceFixture.anyLatitude(),
+                PlaceFixture.anyLongitude()
+        );
+    }
+
+    private SavedCategoryCreateResponse createSavedCategory(final String accessToken) {
+        final SavedCategoryCreateRequest request = new SavedCategoryCreateRequest(
+                SavedCategoryFixture.anyName(),
+                List.of(anyPlaceRequest())
+        );
+
+        return given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(request)
+                .when()
+                .post("/api/saved-categories")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract()
+                .as(SavedCategoryCreateResponse.class);
+    }
+
+    @Nested
+    @DisplayName("보관 카테고리 생성 성공 시나리오")
+    class CreateSavedCategorySuccessScenarios {
+
+        @Test
+        @DisplayName("보관 카테고리 생성에 성공한다")
+        void createSavedCategory_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final String name = SavedCategoryFixture.anyName();
+            final SavedCategoryCreateRequest request = new SavedCategoryCreateRequest(
+                    name,
+                    List.of(anyPlaceRequest())
+            );
+
+            // when
+            final SavedCategoryCreateResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/saved-categories")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .extract()
+                    .as(SavedCategoryCreateResponse.class);
+
+            // then
+            assertThat(response.id()).isNotNull();
+            assertThat(response.name()).isEqualTo(name);
+        }
+    }
+
+    @Nested
+    @DisplayName("보관 카테고리 생성 실패 시나리오")
+    class CreateSavedCategoryFailureScenarios {
+
+        @Test
+        @DisplayName("보관 카테고리 이름이 10자 초과인 경우 생성에 실패한다")
+        void createSavedCategory_fail_nameTooLong() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final SavedCategoryCreateRequest request = new SavedCategoryCreateRequest(
+                    "a".repeat(11),
+                    List.of(anyPlaceRequest())
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/saved-categories")
+                    .then()
+                    .statusCode(HttpStatus.UNPROCESSABLE_ENTITY.value())
+                    .body("code",
+                            org.hamcrest.Matchers.equalTo(ErrorCode.SAVED_CATEGORY_NAME_LENGTH_EXCEEDED.getCode()));
+        }
+
+        @Test
+        @DisplayName("보관 카테고리 이름이 빈 값인 경우 생성에 실패한다")
+        void createSavedCategory_fail_emptyName() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final SavedCategoryCreateRequest request = new SavedCategoryCreateRequest(
+                    "",
+                    List.of(anyPlaceRequest())
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/saved-categories")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.REQUEST_VALIDATION_FAILED.getCode()));
+        }
+
+        @Test
+        @DisplayName("장소 목록이 비어있는 경우 생성에 실패한다")
+        void createSavedCategory_fail_emptyPlaces() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final SavedCategoryCreateRequest request = new SavedCategoryCreateRequest(
+                    SavedCategoryFixture.anyName(),
+                    List.of()
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/saved-categories")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.REQUEST_VALIDATION_FAILED.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("보관 카테고리 단건 조회 성공 시나리오")
+    class ReadSavedCategorySuccessScenarios {
+
+        @Test
+        @DisplayName("보관 카테고리 단건 조회에 성공한다")
+        void readSavedCategory_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final SavedCategoryCreateResponse created = createSavedCategory(accessToken);
+
+            // when
+            final SavedCategoryReadResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(SavedCategoryReadResponse.class);
+
+            // then
+            assertThat(response.id()).isEqualTo(created.id());
+            assertThat(response.name()).isEqualTo(created.name());
+            assertThat(response.savedCategoryPlaceResponses()).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("보관 카테고리 단건 조회 실패 시나리오")
+    class ReadSavedCategoryFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 보관 카테고리 조회 시 실패한다")
+        void readSavedCategory_fail_notFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final Long nonExistentId = 999999L;
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/saved-categories/" + nonExistentId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.SAVED_CATEGORY_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 보관 카테고리 조회 시 실패한다")
+        void readSavedCategory_fail_forbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final SavedCategoryCreateResponse created = createSavedCategory(owner);
+
+            final String otherUser = signUpAndLogin();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .when()
+                    .get("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.SAVED_CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("보관 카테고리 수정 성공 시나리오")
+    class UpdateSavedCategorySuccessScenarios {
+
+        @Test
+        @DisplayName("보관 카테고리 이름 수정에 성공한다")
+        void updateSavedCategory_success_rename() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final SavedCategoryCreateResponse created = createSavedCategory(accessToken);
+
+            final SavedCategoryReadResponse before = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(SavedCategoryReadResponse.class);
+
+            final Long existingPlaceId = before.savedCategoryPlaceResponses().get(0).id();
+            final String newName = SavedCategoryFixture.anyName();
+            final var keepExistingPlace = new SavedCategoryUpdateRequest.SavedCategoryPlaceRequest(
+                    existingPlaceId,
+                    PlaceFixture.anyName(),
+                    PlaceFixture.anyPlaceUrl(),
+                    PlaceFixture.anyRoadAddressName(),
+                    PlaceFixture.anyAddressName(),
+                    PlaceFixture.anyLatitude(),
+                    PlaceFixture.anyLongitude()
+            );
+            final SavedCategoryUpdateRequest request = new SavedCategoryUpdateRequest(newName,
+                    List.of(keepExistingPlace));
+
+            // when
+            final SavedCategoryUpdateResponse response = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .patch("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(SavedCategoryUpdateResponse.class);
+
+            // then
+            assertThat(response.id()).isEqualTo(created.id());
+            assertThat(response.name()).isEqualTo(newName);
+        }
+
+        @Test
+        @DisplayName("보관 카테고리 장소 추가 수정에 성공한다")
+        void updateSavedCategory_success_addPlace() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final SavedCategoryCreateResponse created = createSavedCategory(accessToken);
+
+            final SavedCategoryReadResponse before = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .get("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(SavedCategoryReadResponse.class);
+
+            final Long existingPlaceId = before.savedCategoryPlaceResponses().get(0).id();
+            final var keepExistingPlace = new SavedCategoryUpdateRequest.SavedCategoryPlaceRequest(
+                    existingPlaceId,
+                    PlaceFixture.anyName(),
+                    PlaceFixture.anyPlaceUrl(),
+                    PlaceFixture.anyRoadAddressName(),
+                    PlaceFixture.anyAddressName(),
+                    PlaceFixture.anyLatitude(),
+                    PlaceFixture.anyLongitude()
+            );
+            final var newPlace = new SavedCategoryUpdateRequest.SavedCategoryPlaceRequest(
+                    null,
+                    PlaceFixture.anyName(),
+                    PlaceFixture.anyPlaceUrl(),
+                    PlaceFixture.anyRoadAddressName(),
+                    PlaceFixture.anyAddressName(),
+                    PlaceFixture.anyLatitude(),
+                    PlaceFixture.anyLongitude()
+            );
+            final SavedCategoryUpdateRequest request = new SavedCategoryUpdateRequest(
+                    SavedCategoryFixture.anyName(),
+                    List.of(keepExistingPlace, newPlace)
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .patch("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+        }
+
+        @Test
+        @DisplayName("보관 카테고리 장소 제거 수정에 성공한다")
+        void updateSavedCategory_success_removePlace() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final SavedCategoryCreateResponse created = createSavedCategory(accessToken);
+
+            final var newPlace = new SavedCategoryUpdateRequest.SavedCategoryPlaceRequest(
+                    null,
+                    PlaceFixture.anyName(),
+                    PlaceFixture.anyPlaceUrl(),
+                    PlaceFixture.anyRoadAddressName(),
+                    PlaceFixture.anyAddressName(),
+                    PlaceFixture.anyLatitude(),
+                    PlaceFixture.anyLongitude()
+            );
+            // 기존 장소를 포함하지 않아 삭제, 새 장소 추가
+            final SavedCategoryUpdateRequest request = new SavedCategoryUpdateRequest(
+                    SavedCategoryFixture.anyName(),
+                    List.of(newPlace)
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .patch("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("보관 카테고리 수정 실패 시나리오")
+    class UpdateSavedCategoryFailureScenarios {
+
+        @Test
+        @DisplayName("보관 카테고리 이름이 10자 초과인 경우 수정에 실패한다")
+        void updateSavedCategory_fail_nameTooLong() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final SavedCategoryCreateResponse created = createSavedCategory(accessToken);
+
+            final var placeRequest = new SavedCategoryUpdateRequest.SavedCategoryPlaceRequest(
+                    null,
+                    PlaceFixture.anyName(),
+                    PlaceFixture.anyPlaceUrl(),
+                    PlaceFixture.anyRoadAddressName(),
+                    PlaceFixture.anyAddressName(),
+                    PlaceFixture.anyLatitude(),
+                    PlaceFixture.anyLongitude()
+            );
+            final SavedCategoryUpdateRequest request = new SavedCategoryUpdateRequest(
+                    "a".repeat(11),
+                    List.of(placeRequest)
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .patch("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.UNPROCESSABLE_ENTITY.value())
+                    .body("code",
+                            org.hamcrest.Matchers.equalTo(ErrorCode.SAVED_CATEGORY_NAME_LENGTH_EXCEEDED.getCode()));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 보관 카테고리 수정 시 실패한다")
+        void updateSavedCategory_fail_notFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final Long nonExistentId = 999999L;
+
+            final var placeRequest = new SavedCategoryUpdateRequest.SavedCategoryPlaceRequest(
+                    null,
+                    PlaceFixture.anyName(),
+                    PlaceFixture.anyPlaceUrl(),
+                    PlaceFixture.anyRoadAddressName(),
+                    PlaceFixture.anyAddressName(),
+                    PlaceFixture.anyLatitude(),
+                    PlaceFixture.anyLongitude()
+            );
+            final SavedCategoryUpdateRequest request = new SavedCategoryUpdateRequest(
+                    SavedCategoryFixture.anyName(),
+                    List.of(placeRequest)
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .patch("/api/saved-categories/" + nonExistentId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.SAVED_CATEGORY_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 보관 카테고리 수정 시 실패한다")
+        void updateSavedCategory_fail_forbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final SavedCategoryCreateResponse created = createSavedCategory(owner);
+
+            final String otherUser = signUpAndLogin();
+            final var placeRequest = new SavedCategoryUpdateRequest.SavedCategoryPlaceRequest(
+                    null,
+                    PlaceFixture.anyName(),
+                    PlaceFixture.anyPlaceUrl(),
+                    PlaceFixture.anyRoadAddressName(),
+                    PlaceFixture.anyAddressName(),
+                    PlaceFixture.anyLatitude(),
+                    PlaceFixture.anyLongitude()
+            );
+            final SavedCategoryUpdateRequest request = new SavedCategoryUpdateRequest(
+                    SavedCategoryFixture.anyName(),
+                    List.of(placeRequest)
+            );
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .body(request)
+                    .when()
+                    .patch("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.SAVED_CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("보관 카테고리 삭제 성공 시나리오")
+    class DeleteSavedCategorySuccessScenarios {
+
+        @Test
+        @DisplayName("보관 카테고리 삭제에 성공한다")
+        void deleteSavedCategory_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final SavedCategoryCreateResponse created = createSavedCategory(accessToken);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
+
+        @Test
+        @DisplayName("장소가 여러 개 포함된 보관 카테고리 삭제에 성공한다")
+        void deleteSavedCategory_withPlaces_success() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final SavedCategoryCreateRequest request = new SavedCategoryCreateRequest(
+                    SavedCategoryFixture.anyName(),
+                    List.of(anyPlaceRequest(), anyPlaceRequest(), anyPlaceRequest())
+            );
+
+            final SavedCategoryCreateResponse created = given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/saved-categories")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .extract()
+                    .as(SavedCategoryCreateResponse.class);
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("보관 카테고리 삭제 실패 시나리오")
+    class DeleteSavedCategoryFailureScenarios {
+
+        @Test
+        @DisplayName("존재하지 않는 보관 카테고리 삭제 시 실패한다")
+        void deleteSavedCategory_fail_notFound() {
+            // given
+            final String accessToken = signUpAndLogin();
+            final Long nonExistentId = 999999L;
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .when()
+                    .delete("/api/saved-categories/" + nonExistentId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.SAVED_CATEGORY_NOT_FOUND.getCode()));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 보관 카테고리 삭제 시 실패한다")
+        void deleteSavedCategory_fail_forbidden() {
+            // given
+            final String owner = signUpAndLogin();
+            final SavedCategoryCreateResponse created = createSavedCategory(owner);
+
+            final String otherUser = signUpAndLogin();
+
+            // when & then
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, otherUser)
+                    .when()
+                    .delete("/api/saved-categories/" + created.id())
+                    .then()
+                    .statusCode(HttpStatus.FORBIDDEN.value())
+                    .body("code", org.hamcrest.Matchers.equalTo(ErrorCode.SAVED_CATEGORY_MODIFY_FORBIDDEN.getCode()));
+        }
+    }
+}


### PR DESCRIPTION
## Issues

- closed #125

## ✔️ Check-list

- [x] : 테스트가 모두 통과되었나요?
- [x] : Merge할 브랜치를 확인했나요?

## 🗒️ Work Description

- 보관 카테고리 관련 기능 구현
  - 보관 카테고리 생성 기능
  - 보관 카테고리 수정 기능
  - 보관 카테고리 삭제 기능
  - 보관 카테고리 단건 세부 조회 기능
  - 내 보관 카테고리 목록 조회 기능

## 📷 (Optional) Screenshot

## 📚 (Optional) Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 보관 카테고리 생성, 수정, 삭제 기능 추가
  * 사용자의 보관 카테고리 조회 엔드포인트 추가
  * 각 보관 카테고리 내 장소 관리 기능 지원
  * API 응답에 장소 URL 및 타임존 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->